### PR TITLE
riscv64: Add support to disassemble Zicond instruction

### DIFF
--- a/.github/workflows/go vet.yml
+++ b/.github/workflows/go vet.yml
@@ -55,5 +55,61 @@ jobs:
               echo "No valid Go packages to vet; exiting."
               exit 0
             fi
-            echo "Vetting packages:\n${ok_dirs[*]}"
-            GO111MODULE=off "$GOROOT/bin/go" vet -v "${ok_dirs[@]}"
+            echo "Vetting packages:"
+            printf '%s\n' "${ok_dirs[@]}"
+
+            # Run go vet and capture output without failing immediately
+            # Disable xtrace to reduce noise in logs while filtering
+            set +x
+            set +e
+            GO111MODULE=off "$GOROOT/bin/go" vet -v "${ok_dirs[@]}" > /tmp/vet.out 2>&1
+            VET_STATUS=${PIPESTATUS[0]}
+            set -e
+            # Re-enable xtrace if desired (leave disabled to keep logs clean)
+
+            if [ "$VET_STATUS" -eq 0 ]; then
+              echo "go vet passed with no errors."
+              exit 0
+            fi
+
+            # Build a set of changed files relative to $GOROOT/src
+            mapfile -t CHANGED_REL < <(printf '%s\n' "${CHANGED[@]}" | sed 's|^src/||')
+            declare -A CHANGED_SET=()
+            for f in "${CHANGED_REL[@]}"; do
+              CHANGED_SET["$f"]=1
+              CHANGED_SET["./$f"]=1
+            done
+
+            # Filter vet output: keep errors only for files modified in this PR
+            KEPT_ERRORS=0
+            IGNORED_ERRORS=0
+            > /tmp/vet.kept
+            > /tmp/vet.ignored
+
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^([[:alnum:]_./-]+\.go):([0-9]+): ]]; then
+                file="${BASH_REMATCH[1]}"
+                if [[ ${CHANGED_SET[$file]+_} ]]; then
+                  echo "$line" >> /tmp/vet.kept
+                  KEPT_ERRORS=$((KEPT_ERRORS+1))
+                else
+                  echo "$line" >> /tmp/vet.ignored
+                  IGNORED_ERRORS=$((IGNORED_ERRORS+1))
+                fi
+              fi
+            done < /tmp/vet.out
+
+            if [ "$KEPT_ERRORS" -gt 0 ]; then
+              echo "go vet errors in modified files ($KEPT_ERRORS):" >&2
+              cat /tmp/vet.kept >&2
+              if [ "$IGNORED_ERRORS" -gt 0 ]; then
+                echo "go vet diagnostics ignored in unmodified files ($IGNORED_ERRORS):" >&2
+                cat /tmp/vet.ignored >&2
+              fi
+              exit 1
+            else
+              echo "go vet reported issues only in unmodified files ($IGNORED_ERRORS); ignoring." >&2
+              # Optionally show ignored diagnostics; comment out next line to hide details
+              cat /tmp/vet.ignored >&2 || true
+              exit 0
+            fi

--- a/README-CN.md
+++ b/README-CN.md
@@ -1,0 +1,123 @@
+# Go RISC-V代码仓库贡献指南
+[English Version](README.md) | **中文版本**
+
+代码仓库：https://github.com/zte-riscv/go
+
+## 1. 引言
+本规范适用于中兴与字节跳动共同维护的 Go RISC-V 代码仓库。我们致力于完善 Golang 在 RISC-V 架构的支持，并定期将代码贡献回上游 [golang/go](https://github.com/golang/go) 仓库，同时同步其最新特性。
+
+我们非常欢迎社区开发者参与项目！无论是修复 Bug、实现新功能，还是改进文档，您的贡献都将帮助推动 RISC-V 生态的发展。
+
+为确保协作高效顺畅，请在提交代码前阅读以下指南：
+
+
+## 2. 提交前准备
+### 2.1 问题跟踪与讨论
+**必须**：
+- 在开始实质性工作前创建或认领相关Issue
+- 在Issue中明确描述变更动机、设计方案和预期影响
+
+**建议**：
+- 对于重大变更（如新指令集支持、架构修改），提前提交设计文档进行评审
+
+### 2.2 分支管理
+```bash
+# 从当前开发分支（如go1.25.0-zte-dev）创建特性分支：
+git fetch origin
+git checkout -b your_dev_branch origin/go1.25.0-zte-dev
+```
+
+## 3. 代码贡献流程
+### 3.1 开发工作流
+**Issue提交**：
+- 错误报告：记录问题现象、环境及复现步骤
+- 功能/优化：说明技术背景和实现策略
+
+**Pull Request提交**：
+- 在PR描述中提供任务背景并关联相关Issue
+- 提交前在本地解决所有合并冲突
+
+**CI与评审**：
+- PR提交后将自动执行测试套件（测试失败将阻止合并）
+- 需获得指定评审人的批准方可合并，评审人回复+1或+2。
+
+**合并策略**：
+- 所有提交以sqash merge的方式压缩为单个commit后合入目标分支
+
+### 3.2 提交信息规范
+压缩提交时请遵循以下格式：
+```bash
+git commit -m "包名: 简洁的变更摘要
+
+修复 #12345
+更新 #67890"
+```
+- **标题**：包名前缀 + 简要说明（<50字符）
+- **页脚**：包含相关issue引用
+
+## 4. 评审流程
+### 4.1 强制要求
+- CI流水线必须通过
+- 最低审批要求：
+- 1名中兴核心维护者的+2
+- 1名字节跳动核心维护者的+2
+
+### 4.2 评审等级
+- `+1`：初步批准（需额外评审人）
+- `+2`：最终批准（可合并）
+
+**对维护者和评审人的要求：
+批准合并时，请回复+1或+2。**
+
+### 4.3 核心维护团队
+| GitHub | Role | Org | Auth Level |
+|--------|------|-----|-----------|
+| @agiledragon | Maintainer | ZTE | +2 |
+| @ctk-1998 | Reviewer | ZTE | +1 |
+| @lxq015 | Reviewer | ZTE | +1 |
+| @hehongjun20110618 | Maintainer | ZTE | +2 |
+| @newborn22 | Maintainer | ZTE | +2 |
+| @wenchangping | Reviewer | ZTE | +1 |
+| @wangpc-pp | Maintainer | ByteDance | +2 |
+| @BoyaoWang430 | Reviewer | ByteDance | +1 |
+
+### 4.4 评审检查清单
+- ✅ 符合Go编码规范
+- ✅ 通过CI流水线
+- ✅ 包含对应测试用例
+- ✅ 性能基准测试（如适用）
+
+## 5. CI流水线要求
+### 5.1 测试要求
+- **静态分析**：对涉及修改的代码包执行`go vet`
+- **代码生成验证**：通过`asmcheck`验证RISCV64架构下是否生成了正确的指令（`go/test/codegen/`）
+- **汇编测试**：验证汇编指令是否生成正确的机器码（`go/src/cmd/asm/internal/asm/testdata/riscv64.s`）
+- **回归测试**：在x86/ARM架构执行`go/src/all.bash`
+- **应用测试**：QEMU-RISCV环境下验证测试文件是否正确执行（`go/test/zte/*_test.go`）
+
+## 6. 性能报告（可选）
+### 6.1 基准测试要求
+对性能敏感变更需提供如下信息：
+
+测试环境：
+```markdown
+- 硬件：[如SiFive Unmatched, VisionFive2]
+- Go版本：
+- 测试日期：
+- CPU（可选）：[核心数、频率、RISC-V扩展指令]
+- 内存（可选）：
+```
+
+基准测试结果，`benchstat`对比：
+```bash
+benchstat old.txt new.txt
+
+name        old time/op     new time/op    delta    
+Fibonacci   125ms ± 2%      98ms ± 3%      -21.60% (p=0.000 n=10+10) 
+Sort        456ms ± 1%      401ms± 2%      -12.06% (p=0.000 n=9+10)
+
+```
+
+## 7. 附录
+官方Go贡献指南：https://golang.org/doc/contribute
+

--- a/README.md
+++ b/README.md
@@ -1,42 +1,119 @@
-# The Go Programming Language
+# Contribution Guidelines for Go RISC-V Repository
+**English Version** | [中文版本](README-CN.md)
 
-Go is an open source programming language that makes it easy to build simple,
-reliable, and efficient software.
+Repository: https://github.com/zte-riscv/go
 
-![Gopher image](https://golang.org/doc/gopher/fiveyears.jpg)
-*Gopher image by [Renee French][rf], licensed under [Creative Commons 4.0 Attribution license][cc4-by].*
+## 1. Introduction
+This specification applies to the Go RISC-V code repository jointly maintained by ZTE and ByteDance. We are committed to enhancing Golang support for RISC-V architecture, regularly contributing code upstream to [golang/go](https://github.com/golang/go) while synchronizing with its latest features.
 
-Our canonical Git repository is located at https://go.googlesource.com/go.
-There is a mirror of the repository at https://github.com/golang/go.
+We warmly welcome community developers to participate! Whether it's fixing bugs, implementing new features, or improving documentation, your contributions will help advance the RISC-V ecosystem.
 
-Unless otherwise noted, the Go source files are distributed under the
-BSD-style license found in the LICENSE file.
+To ensure efficient collaboration, please review the following guidelines before submitting code:
 
-### Download and Install
+## 2. Pre-Submission Preparation
+### 2.1 Issue Tracking and Discussion
+**Mandatory**:
+- Create or claim a related Issue before commencing substantive work
+- Clearly describe the change motivation, design approach, and expected impact in the Issue
 
-#### Binary Distributions
+**Recommended**:
+- For significant changes (e.g., new instruction set support, architectural modifications), submit a design document for prior review
 
-Official binary distributions are available at https://go.dev/dl/.
+### 2.2 Branch Management
+```bash
+# Create a feature branch from the current development branch (e.g., go1.25.0-zte-dev):
+git fetch origin
+git checkout -b your_dev_branch origin/go1.25.0-zte-dev
+```
 
-After downloading a binary release, visit https://go.dev/doc/install
-for installation instructions.
+## 3. Code Contribution Process
+### 3.1 Development Workflow
+**Issue Submission**:
+- For bug reports: Document the problem, environment, and reproduction steps
+- For features/optimizations: Describe the technical background and implementation strategy
 
-#### Install From Source
+**Pull Request Submission**:
+- Provide task context in the PR description and reference related Issues
+- Resolve all merge conflicts locally before submission
 
-If a binary distribution is not available for your combination of
-operating system and architecture, visit
-https://go.dev/doc/install/source
-for source installation instructions.
+**CI and Review**:
+- Automated test suites will execute upon PR submission (failed tests block merging)
+- Require approvals from designated reviewers before merging, reviewers comment +1 or +2.
 
-### Contributing
+**Merge Policy**:
+- All commits must be squashed into a single commit
 
-Go is the work of thousands of contributors. We appreciate your help!
+### 3.2 Commit Message Standards
+For squashed commits, follow this format:
+```bash
+git commit -m "package: concise change summary
 
-To contribute, please read the contribution guidelines at https://go.dev/doc/contribute.
+Fixes #12345
+Updates #67890"
+```
+- **Header**: Package prefix + brief description (<50 chars)
+- **Footer**: Issue references
 
-Note that the Go project uses the issue tracker for bug reports and
-proposals only. See https://go.dev/wiki/Questions for a list of
-places to ask questions about the Go language.
+## 4. Review Process
+### 4.1 Mandatory Requirements
+- CI pipeline must pass
+- Minimum approvals:
+- One +2 from ZTE core maintainers
+- One +2 from ByteDance core maintainers
 
-[rf]: https://reneefrench.blogspot.com/
-[cc4-by]: https://creativecommons.org/licenses/by/4.0/
+### 4.2 Review Tiers
+- `+1`: Preliminary approval (requires additional reviewer)
+- `+2`: Final approval for merging
+
+**For maintainers and reviewers: 
+when approving the merge, please respond with either +1 or +2.**
+
+### 4.3 Core Maintainers
+| GitHub | Role | Org | Auth Level |
+|--------|------|-----|-----------|
+| @agiledragon | Maintainer | ZTE | +2 |
+| @ctk-1998 | Reviewer | ZTE | +1 |
+| @lxq015 | Reviewer | ZTE | +1 |
+| @hehongjun20110618 | Maintainer | ZTE | +2 |
+| @newborn22 | Maintainer | ZTE | +2 |
+| @wenchangping | Reviewer | ZTE | +1 |
+| @wangpc-pp | Maintainer | ByteDance | +2 |
+| @BoyaoWang430 | Reviewer | ByteDance | +1 |
+
+### 4.4 Review Checklist
+- ✅ Go coding standards compliance
+- ✅ Passing CI pipelines
+- ✅ Corresponding test coverage
+- ✅ Performance benchmarks (where applicable)
+
+## 5. CI Pipeline Requirements
+### 5.1 Test
+- **Static Analysis**: Run `go vet` on all modified code packages
+- **Codegen Validation**: Verify RISCV64 instruction generation via `asmcheck` (`go/test/codegen/`)
+- **Assembly Tests**: Validate machine code output from assembly instructions (`go/src/cmd/asm/internal/asm/testdata/riscv64.s`)
+- **Regression Testing**: Execute `go/src/all.bash` on x86/ARM architectures
+- **Application Testing**: Validate test file execution in QEMU-RISCV environment (`go/test/zte/*_test.go`)
+
+## 6. Performance Reporting (Optional)
+### 6.1 Benchmark Requirements
+For performance-sensitive changes:
+
+Test Environment:
+```markdown
+- Hardware: [e.g., SiFive Unmatched, VisionFive2]
+- Go Version:
+- Test Date:
+- CPU (Optional): [Cores, frequency, RISC-V extensions]
+- Memory (Optional):
+```
+Benchmark Results, `benchstat` comparison:
+```bash
+benchstat old.txt new.txt
+
+name        old time/op     new time/op    delta    
+Fibonacci   125ms ± 2%      98ms ± 3%      -21.60% (p=0.000 n=10+10) 
+Sort        456ms ± 1%      401ms± 2%      -12.06% (p=0.000 n=9+10)
+
+```
+## 7. Appendix
+Official Go Contribution Guide: https://golang.org/doc/contribute

--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -3923,9 +3923,6 @@ func instructionsForProg(p *obj.Prog) []*instruction {
 			ins.rd = uint32(p.From.Reg)
 		}
 		ins.rs1, ins.rs2 = obj.REG_NONE, REG_V0
-	case ACZERONEZ, ACZEROEQZ:
-		// Zicond instructions: rd, rs1, rs2
-		ins.rd, ins.rs1, ins.rs2 = uint32(p.To.Reg), uint32(p.Reg), uint32(p.From.Reg)
 	}
 
 	for _, ins := range inss {

--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -3923,6 +3923,9 @@ func instructionsForProg(p *obj.Prog) []*instruction {
 			ins.rd = uint32(p.From.Reg)
 		}
 		ins.rs1, ins.rs2 = obj.REG_NONE, REG_V0
+	case ACZERONEZ, ACZEROEQZ:
+		// Zicond instructions: rd, rs1, rs2
+		ins.rd, ins.rs1, ins.rs2 = uint32(p.To.Reg), uint32(p.Reg), uint32(p.From.Reg)
 	}
 
 	for _, ins := range inss {

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
@@ -116,8 +116,8 @@ const (
 	CSRRWI
 	CTZ
 	CTZW
-	CZERONEZ
-	CZEROEQZ
+	CZERO_EQZ
+	CZERO_NEZ
 	C_ADD
 	C_ADDI
 	C_ADDI16SP
@@ -485,8 +485,8 @@ var opstr = [...]string{
 	CSRRWI:         "CSRRWI",
 	CTZ:            "CTZ",
 	CTZW:           "CTZW",
-	CZERONEZ:       "CZERONEZ",
-	CZEROEQZ:       "CZEROEQZ",
+	CZERO_EQZ:	"CZERO.EQZ",
+	CZERO_NEZ:	"CZERO.NEZ",
 	C_ADD:          "C.ADD",
 	C_ADDI:         "C.ADDI",
 	C_ADDI16SP:     "C.ADDI16SP",
@@ -961,10 +961,10 @@ var instFormats = [...]instFormat{
 	{mask: 0xfff0707f, value: 0x60101013, op: CTZ, args: argTypeList{arg_rd, arg_rs1}},
 	// CTZW rd, rs1
 	{mask: 0xfff0707f, value: 0x6010101b, op: CTZW, args: argTypeList{arg_rd, arg_rs1}},
-	// CZERONEZ rd, rs1, rs2
-	{mask: 0xfe00707f, value: 0x0e007033, op: CZERONEZ, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
-	// CZEROEQZ rd, rs1, rs2
-	{mask: 0xfe00707f, value: 0x0e005033, op: CZEROEQZ, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},	
+	// CZERO.EQZ rd, rs1, rs2
+	{mask: 0xfe00707f, value: 0x0e005033, op: CZERO_EQZ, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
+	// CZERO.NEZ rd, rs1, rs2
+	{mask: 0xfe00707f, value: 0x0e007033, op: CZERO_NEZ, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// C.ADD rd_rs1_n0, c_rs2_n0
 	{mask: 0x0000f003, value: 0x00009002, op: C_ADD, args: argTypeList{arg_rd_rs1_n0, arg_c_rs2_n0}},
 	// C.ADDI rd_rs1_n0, c_nzimm6

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
@@ -116,6 +116,8 @@ const (
 	CSRRWI
 	CTZ
 	CTZW
+	CZERONEZ
+	CZEROEQZ
 	C_ADD
 	C_ADDI
 	C_ADDI16SP
@@ -483,6 +485,8 @@ var opstr = [...]string{
 	CSRRWI:         "CSRRWI",
 	CTZ:            "CTZ",
 	CTZW:           "CTZW",
+	CZERONEZ:       "CZERONEZ",
+	CZEROEQZ:       "CZEROEQZ",
 	C_ADD:          "C.ADD",
 	C_ADDI:         "C.ADDI",
 	C_ADDI16SP:     "C.ADDI16SP",
@@ -957,6 +961,10 @@ var instFormats = [...]instFormat{
 	{mask: 0xfff0707f, value: 0x60101013, op: CTZ, args: argTypeList{arg_rd, arg_rs1}},
 	// CTZW rd, rs1
 	{mask: 0xfff0707f, value: 0x6010101b, op: CTZW, args: argTypeList{arg_rd, arg_rs1}},
+	// CZERONEZ rd, rs1, rs2
+	{mask: 0xfe00707f, value: 0x0e007033, op: CZERONEZ, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
+	// CZEROEQZ rd, rs1, rs2
+	{mask: 0xfe00707f, value: 0x0e005033, op: CZEROEQZ, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},	
 	// C.ADD rd_rs1_n0, c_rs2_n0
 	{mask: 0x0000f003, value: 0x00009002, op: C_ADD, args: argTypeList{arg_rd_rs1_n0, arg_c_rs2_n0}},
 	// C.ADDI rd_rs1_n0, c_nzimm6


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
#2 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required