### PR TITLE
CI: go vet workflow: ignore errors of unchanged files in go vet

### DIFF
--- a/.github/workflows/go vet.yml
+++ b/.github/workflows/go vet.yml
@@ -96,9 +96,6 @@ jobs:
                   echo "$line" >> /tmp/vet.ignored
                   IGNORED_ERRORS=$((IGNORED_ERRORS+1))
                 fi
-              else
-                # Drop non-diagnostic / context lines to keep logs concise
-                :
               fi
             done < /tmp/vet.out
 

--- a/.github/workflows/go vet.yml
+++ b/.github/workflows/go vet.yml
@@ -59,10 +59,13 @@ jobs:
             printf '%s\n' "${ok_dirs[@]}"
 
             # Run go vet and capture output without failing immediately
+            # Disable xtrace to reduce noise in logs while filtering
+            set +x
             set +e
-            GO111MODULE=off "$GOROOT/bin/go" vet -v "${ok_dirs[@]}" 2>&1 | tee /tmp/vet.out
+            GO111MODULE=off "$GOROOT/bin/go" vet -v "${ok_dirs[@]}" > /tmp/vet.out 2>&1
             VET_STATUS=${PIPESTATUS[0]}
             set -e
+            # Re-enable xtrace if desired (leave disabled to keep logs clean)
 
             if [ "$VET_STATUS" -eq 0 ]; then
               echo "go vet passed with no errors."
@@ -79,6 +82,7 @@ jobs:
 
             # Filter vet output: keep errors only for files modified in this PR
             KEPT_ERRORS=0
+            IGNORED_ERRORS=0
             > /tmp/vet.kept
             > /tmp/vet.ignored
 
@@ -89,22 +93,26 @@ jobs:
                   echo "$line" >> /tmp/vet.kept
                   KEPT_ERRORS=$((KEPT_ERRORS+1))
                 else
-                  echo "Ignoring vet issue in unmodified file: $file" >&2
                   echo "$line" >> /tmp/vet.ignored
+                  IGNORED_ERRORS=$((IGNORED_ERRORS+1))
                 fi
               else
-                # Non-diagnostic / context lines: attach to kept for visibility
-                echo "$line" >> /tmp/vet.kept
+                # Drop non-diagnostic / context lines to keep logs concise
+                :
               fi
             done < /tmp/vet.out
 
             if [ "$KEPT_ERRORS" -gt 0 ]; then
-              echo "go vet errors in modified files:" >&2
+              echo "go vet errors in modified files ($KEPT_ERRORS):" >&2
               cat /tmp/vet.kept >&2
+              if [ "$IGNORED_ERRORS" -gt 0 ]; then
+                echo "go vet diagnostics ignored in unmodified files ($IGNORED_ERRORS):" >&2
+                cat /tmp/vet.ignored >&2
+              fi
               exit 1
             else
-              echo "go vet reported issues only in unmodified files; ignoring." >&2
-              # Show ignored diagnostics for visibility
+              echo "go vet reported issues only in unmodified files ($IGNORED_ERRORS); ignoring." >&2
+              # Optionally show ignored diagnostics; comment out next line to hide details
               cat /tmp/vet.ignored >&2 || true
               exit 0
             fi

--- a/.github/workflows/go vet.yml
+++ b/.github/workflows/go vet.yml
@@ -55,5 +55,56 @@ jobs:
               echo "No valid Go packages to vet; exiting."
               exit 0
             fi
-            echo "Vetting packages:\n${ok_dirs[*]}"
-            GO111MODULE=off "$GOROOT/bin/go" vet -v "${ok_dirs[@]}"
+            echo "Vetting packages:"
+            printf '%s\n' "${ok_dirs[@]}"
+
+            # Run go vet and capture output without failing immediately
+            set +e
+            GO111MODULE=off "$GOROOT/bin/go" vet -v "${ok_dirs[@]}" 2>&1 | tee /tmp/vet.out
+            VET_STATUS=${PIPESTATUS[0]}
+            set -e
+
+            if [ "$VET_STATUS" -eq 0 ]; then
+              echo "go vet passed with no errors."
+              exit 0
+            fi
+
+            # Build a set of changed files relative to $GOROOT/src
+            mapfile -t CHANGED_REL < <(printf '%s\n' "${CHANGED[@]}" | sed 's|^src/||')
+            declare -A CHANGED_SET=()
+            for f in "${CHANGED_REL[@]}"; do
+              CHANGED_SET["$f"]=1
+              CHANGED_SET["./$f"]=1
+            done
+
+            # Filter vet output: keep errors only for files modified in this PR
+            KEPT_ERRORS=0
+            > /tmp/vet.kept
+            > /tmp/vet.ignored
+
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^([[:alnum:]_./-]+\.go):([0-9]+): ]]; then
+                file="${BASH_REMATCH[1]}"
+                if [[ ${CHANGED_SET[$file]+_} ]]; then
+                  echo "$line" >> /tmp/vet.kept
+                  KEPT_ERRORS=$((KEPT_ERRORS+1))
+                else
+                  echo "Ignoring vet issue in unmodified file: $file" >&2
+                  echo "$line" >> /tmp/vet.ignored
+                fi
+              else
+                # Non-diagnostic / context lines: attach to kept for visibility
+                echo "$line" >> /tmp/vet.kept
+              fi
+            done < /tmp/vet.out
+
+            if [ "$KEPT_ERRORS" -gt 0 ]; then
+              echo "go vet errors in modified files:" >&2
+              cat /tmp/vet.kept >&2
+              exit 1
+            else
+              echo "go vet reported issues only in unmodified files; ignoring." >&2
+              # Show ignored diagnostics for visibility
+              cat /tmp/vet.ignored >&2 || true
+              exit 0
+            fi


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
The background and proposal are described in #11. 

A concrete example of the effects introduced by this PR is as follows:
Before:
```
...
cmd/compile/internal/ssa/_gen/rulegen.go:858:30: non-constant format string in call to cmd/compile/internal/ssa/_gen.exprf
cmd/compile/internal/ssa/_gen/rulegen.go:885:32: non-constant format string in call to cmd/compile/internal/ssa/_gen.declf
cmd/compile/internal/ssa/_gen/rulegen.go:900:30: non-constant format string in call to cmd/compile/internal/ssa/_gen.declf
...
Error: Process completed with exit code 1.
```
After (test in draft PR #9):
```
go vet reported issues only in unmodified files (3); ignoring.
cmd/compile/internal/ssa/_gen/rulegen.go:858:30: non-constant format string in call to cmd/compile/internal/ssa/_gen.exprf
cmd/compile/internal/ssa/_gen/rulegen.go:885:32: non-constant format string in call to cmd/compile/internal/ssa/_gen.declf
cmd/compile/internal/ssa/_gen/rulegen.go:900:30: non-constant format string in call to cmd/compile/internal/ssa/_gen.declf
```


<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required