### PR TITLE
riscv64: Add support to disassemble Zicond instruction

### DIFF
--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
@@ -116,6 +116,8 @@ const (
 	CSRRWI
 	CTZ
 	CTZW
+	CZERO_EQZ
+	CZERO_NEZ
 	C_ADD
 	C_ADDI
 	C_ADDI16SP
@@ -483,6 +485,8 @@ var opstr = [...]string{
 	CSRRWI:         "CSRRWI",
 	CTZ:            "CTZ",
 	CTZW:           "CTZW",
+	CZERO_EQZ:		"CZERO.EQZ",
+	CZERO_NEZ:		"CZERO.NEZ",
 	C_ADD:          "C.ADD",
 	C_ADDI:         "C.ADDI",
 	C_ADDI16SP:     "C.ADDI16SP",
@@ -957,6 +961,10 @@ var instFormats = [...]instFormat{
 	{mask: 0xfff0707f, value: 0x60101013, op: CTZ, args: argTypeList{arg_rd, arg_rs1}},
 	// CTZW rd, rs1
 	{mask: 0xfff0707f, value: 0x6010101b, op: CTZW, args: argTypeList{arg_rd, arg_rs1}},
+	// CZERO.EQZ rd, rs1, rs2
+	{mask: 0xfe00707f, value: 0x0e005033, op: CZERO_EQZ, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
+	// CZERO.NEZ rd, rs1, rs2
+	{mask: 0xfe00707f, value: 0x0e007033, op: CZERO_NEZ, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// C.ADD rd_rs1_n0, c_rs2_n0
 	{mask: 0x0000f003, value: 0x00009002, op: C_ADD, args: argTypeList{arg_rd_rs1_n0, arg_c_rs2_n0}},
 	// C.ADDI rd_rs1_n0, c_nzimm6


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
This patch support to disassemble Zicond instruction
#2 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required