### PR TITLE
cmd/internal/obj/riscv: support vector unit-stride fault-only-first load instructions

### DIFF
--- a/src/cmd/asm/internal/asm/testdata/riscv64.s
+++ b/src/cmd/asm/internal/asm/testdata/riscv64.s
@@ -544,6 +544,16 @@ start:
 	VSOXEI64V	V3, V2, (X10)			// a771250e
 	VSOXEI64V	V3, V2, V0, (X10)		// a771250c
 
+	// 31.7.7: Unit-stride Fault-Only-First Loads
+	VLE8FFV		(X10), V8				// 07040503
+	VLE16FFV	(X10), V8				// 07540503
+	VLE32FFV	(X10), V8				// 07640503
+	VLE64FFV	(X10), V8				// 07740503
+	VLE8FFV		(X10), V0, V8			// 07040501
+	VLE16FFV	(X10), V0, V8			// 07540501
+	VLE32FFV	(X10), V0, V8			// 07640501
+	VLE64FFV	(X10), V0, V8			// 07740501
+
 	// 31.7.8: Vector Load/Store Segment Instructions
 
 	// 31.7.8.1: Vector Unit-Stride Segment Loads and Stores

--- a/src/cmd/asm/internal/asm/testdata/riscv64error.s
+++ b/src/cmd/asm/internal/asm/testdata/riscv64error.s
@@ -73,6 +73,7 @@ TEXT errors(SB),$0
 	//
 	VSETIVLI	X10, E32, M2, TA, MA, X12	// ERROR "expected immediate value"
 	VLE8V		(X10), V1, V3			// ERROR "invalid vector mask register"
+	VLE8FFV		(X10), V1, V3			// ERROR "invalid vector mask register"
 	VSE8V		V3, V1, (X10)			// ERROR "invalid vector mask register"
 	VLSE8V		(X10), X10, V1, V3		// ERROR "invalid vector mask register"
 	VSSE8V		V3, X11, V1, (X10)		// ERROR "invalid vector mask register"

--- a/src/cmd/asm/internal/asm/testdata/riscv64validation.s
+++ b/src/cmd/asm/internal/asm/testdata/riscv64validation.s
@@ -20,6 +20,8 @@ TEXT validation(SB),$0
 	VSETVL		X10, X11			// ERROR "expected integer register in rs1 position"
 	VLE8V		(X10), X10			// ERROR "expected vector register in vd position"
 	VLE8V		(V1), V3			// ERROR "expected integer register in rs1 position"
+	VLE8FFV		(X10), X10			// ERROR "expected vector register in vd position"
+	VLE8FFV		(V1), V3			// ERROR "expected integer register in rs1 position"
 	VSE8V		X10, (X10)			// ERROR "expected vector register in vs1 position"
 	VSE8V		V3, (V1)			// ERROR "expected integer register in rd position"
 	VLSE8V		(X10), V3			// ERROR "expected integer register in rs2 position"

--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -2546,6 +2546,12 @@ var instructions = [ALAST & obj.AMask]instructionData{
 	AVSUXSEG7EI64V & obj.AMask: {enc: sVIVEncoding},
 	AVSUXSEG8EI64V & obj.AMask: {enc: sVIVEncoding},
 
+	// 31.7.7: Unit-stride Fault-Only-First Loads
+	AVLE8FFV & obj.AMask:  {enc: iVEncoding},
+	AVLE16FFV & obj.AMask: {enc: iVEncoding},
+	AVLE32FFV & obj.AMask: {enc: iVEncoding},
+	AVLE64FFV & obj.AMask: {enc: iVEncoding},
+
 	// 31.7.9: Vector Load/Store Whole Register Instructions
 	AVL1RE8V & obj.AMask:  {enc: iVEncoding},
 	AVL1RE16V & obj.AMask: {enc: iVEncoding},
@@ -3994,7 +4000,7 @@ func instructionsForProg(p *obj.Prog) []*instruction {
 			ins.rs1 = uint32(p.From.Offset)
 		}
 
-	case AVLE8V, AVLE16V, AVLE32V, AVLE64V, AVSE8V, AVSE16V, AVSE32V, AVSE64V, AVLMV, AVSMV,
+	case AVLE8V, AVLE16V, AVLE32V, AVLE64V, AVSE8V, AVSE16V, AVSE32V, AVSE64V, AVLE8FFV, AVLE16FFV, AVLE32FFV, AVLE64FFV, AVLMV, AVSMV,
 		AVLSEG2E8V, AVLSEG3E8V, AVLSEG4E8V, AVLSEG5E8V, AVLSEG6E8V, AVLSEG7E8V, AVLSEG8E8V,
 		AVLSEG2E16V, AVLSEG3E16V, AVLSEG4E16V, AVLSEG5E16V, AVLSEG6E16V, AVLSEG7E16V, AVLSEG8E16V,
 		AVLSEG2E32V, AVLSEG3E32V, AVLSEG4E32V, AVLSEG5E32V, AVLSEG6E32V, AVLSEG7E32V, AVLSEG8E32V,


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
#23

Disassembler support is not included in this change.
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required