### PR TITLE
cmd/vendor/golang.org/x/arch: add disasm support for Zicfiss

### DIFF
--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
@@ -282,6 +282,20 @@ func GNUSyntax(inst Inst) string {
 		num |= (inst.Enc >> 26) & 0x1 << 0
 		op = fmt.Sprintf("mop.rr.%d", num)
 
+		switch num {
+		case moprr7:
+			if inst.Args[0].(Reg) == X0 && inst.Args[1].(Reg) == X0 {
+				switch inst.Args[2].(Reg) {
+				case X1:
+					op = "sspush.x1"
+					args = nil
+				case X5:
+					op = "sspush.x5"
+					args = nil
+				}
+			}
+		}
+
 	case MOP_R_N:
 		num := (inst.Enc >> 30) & 0x1 << 4
 		num |= (inst.Enc >> 27) & 0x1 << 3
@@ -289,6 +303,23 @@ func GNUSyntax(inst Inst) string {
 		num |= (inst.Enc >> 21) & 0x1 << 1
 		num |= (inst.Enc >> 20) & 0x1 << 0
 		op = fmt.Sprintf("mop.r.%d", num)
+
+		switch num {
+		case mopr28:
+			if inst.Args[0].(Reg) == X0 {
+				switch inst.Args[1].(Reg) {
+				case X1:
+					op = "sspopchk.x1"
+					args = nil
+				case X5:
+					op = "sspopchk.x5"
+					args = nil
+				}
+			} else if inst.Args[1].(Reg) == X0 {
+				op = "ssrdp"
+				args = args[0:1]
+			}
+		}
 
 	case JAL:
 		if inst.Args[0].(Reg) == X0 {

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
@@ -493,3 +493,49 @@ func (memOrder MemOrder) String() string {
 	}
 	return str
 }
+
+const (
+	mopr0 = iota
+	mopr1
+	mopr2
+	mopr3
+	mopr4
+	mopr5
+	mopr6
+	mopr7
+	mopr8
+	mopr9
+	mopr10
+	mopr11
+	mopr12
+	mopr13
+	mopr14
+	mopr15
+	mopr16
+	mopr17
+	mopr18
+	mopr19
+	mopr20
+	mopr21
+	mopr22
+	mopr23
+	mopr24
+	mopr25
+	mopr26
+	mopr27
+	mopr28
+	mopr29
+	mopr30
+	mopr31
+)
+
+const (
+	moprr0 = iota
+	moprr1
+	moprr2
+	moprr3
+	moprr4
+	moprr5
+	moprr6
+	moprr7
+)

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
@@ -301,6 +301,20 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 		num |= (inst.Enc >> 26) & 0x1 << 0
 		op = fmt.Sprintf("MOPRR%d", num)
 
+		switch num {
+		case moprr7:
+			if inst.Args[0].(Reg) == X0 && inst.Args[1].(Reg) == X0 {
+				switch inst.Args[2].(Reg) {
+				case X1:
+					op = "SSPUSHX1"
+					args = nil
+				case X5:
+					op = "SSPUSHX5"
+					args = nil
+				}
+			}
+		}
+
 	case MOP_R_N:
 		num := (inst.Enc >> 30) & 0x1 << 4
 		num |= (inst.Enc >> 27) & 0x1 << 3
@@ -308,6 +322,23 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 		num |= (inst.Enc >> 21) & 0x1 << 1
 		num |= (inst.Enc >> 20) & 0x1 << 0
 		op = fmt.Sprintf("MOPR%d", num)
+
+		switch num {
+		case mopr28:
+			if inst.Args[0].(Reg) == X0 {
+				switch inst.Args[1].(Reg) {
+				case X1:
+					op = "SSPOPCHKX1"
+					args = nil
+				case X5:
+					op = "SSPOPCHKX5"
+					args = nil
+				}
+			} else if inst.Args[1].(Reg) == X0 {
+				op = "SSRDP"
+				args = args[0:1]
+			}
+		}
 
 	case SUB:
 		if inst.Args[1].(Reg) == X0 {

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
@@ -63,7 +63,8 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 		AMOOR_H_RL, AMOSWAP_B, AMOSWAP_B_AQ, AMOSWAP_B_AQRL, AMOSWAP_B_RL, AMOSWAP_H,
 		AMOSWAP_H_AQ, AMOSWAP_H_AQRL, AMOSWAP_H_RL, AMOXOR_B, AMOXOR_B_AQ, AMOXOR_B_AQRL,
 		AMOXOR_B_RL, AMOXOR_H, AMOXOR_H_AQ, AMOXOR_H_AQRL, AMOXOR_H_RL,
-		SC_D, SC_D_AQ, SC_D_RL, SC_D_AQRL, SC_W, SC_W_AQ, SC_W_RL, SC_W_AQRL:
+		SC_D, SC_D_AQ, SC_D_RL, SC_D_AQRL, SC_W, SC_W_AQ, SC_W_RL, SC_W_AQRL,
+		SSAMOSWAP_D, SSAMOSWAP_W:
 		// Atomic instructions have special operand order.
 		args[2], args[1] = args[1], args[2]
 

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
@@ -454,6 +454,8 @@ const (
 	SRLI
 	SRLIW
 	SRLW
+	SSAMOSWAP_D
+	SSAMOSWAP_W
 	SUB
 	SUBW
 	SW
@@ -911,6 +913,8 @@ var opstr = [...]string{
 	SRLI:           "SRLI",
 	SRLIW:          "SRLIW",
 	SRLW:           "SRLW",
+	SSAMOSWAP_D:    "SSAMOSWAP.D",
+	SSAMOSWAP_W:    "SSAMOSWAP.W",
 	SUB:            "SUB",
 	SUBW:           "SUBW",
 	SW:             "SW",
@@ -1813,6 +1817,10 @@ var instFormats = [...]instFormat{
 	{mask: 0xfe00707f, value: 0x0000501b, op: SRLIW, args: argTypeList{arg_rd, arg_rs1, arg_shamt5}},
 	// SRLW rd, rs1, rs2
 	{mask: 0xfe00707f, value: 0x0000503b, op: SRLW, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
+	// SSAMOSWAP.D rd, rs2, rs1_amo
+	{mask: 0xf800707f, value: 0x4800302f, op: SSAMOSWAP_D, args: argTypeList{arg_rd, arg_rs2, arg_rs1_amo}},
+	// SSAMOSWAP.W rd, rs2, rs1_amo
+	{mask: 0xf800707f, value: 0x4800202f, op: SSAMOSWAP_W, args: argTypeList{arg_rd, arg_rs2, arg_rs1_amo}},
 	// SUB rd, rs1, rs2
 	{mask: 0xfe00707f, value: 0x40000033, op: SUB, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// SUBW rd, rs1, rs2


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required