### PR TITLE
cmd/vendor/golang.org/x/arch: add disassembly support for Zawrs extension

### DIFF
--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
@@ -451,6 +451,8 @@ const (
 	SUB
 	SUBW
 	SW
+	WRS_NTO
+	WRS_STO
 	XNOR
 	XOR
 	XORI
@@ -900,6 +902,8 @@ var opstr = [...]string{
 	SUB:            "SUB",
 	SUBW:           "SUBW",
 	SW:             "SW",
+	WRS_NTO:        "WRS.NTO",
+	WRS_STO:        "WRS.STO",
 	XNOR:           "XNOR",
 	XOR:            "XOR",
 	XORI:           "XORI",
@@ -1791,6 +1795,10 @@ var instFormats = [...]instFormat{
 	{mask: 0xfe00707f, value: 0x4000003b, op: SUBW, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// SW rs2, rs1_store
 	{mask: 0x0000707f, value: 0x00002023, op: SW, args: argTypeList{arg_rs2, arg_rs1_store}},
+	// WRS.NTO
+	{mask: 0xffffffff, value: 0x00d00073, op: WRS_NTO, args: argTypeList{}},
+	// WRS.STO
+	{mask: 0xffffffff, value: 0x01d00073, op: WRS_STO, args: argTypeList{}},
 	// XNOR rd, rs1, rs2
 	{mask: 0xfe00707f, value: 0x40004033, op: XNOR, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// XOR rd, rs1, rs2


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
#47 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required