### PR TITLE
cmd/vendor/golang.org/x/arch: add disassembly support for zihintntl extension

### DIFF
--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
@@ -59,9 +59,28 @@ func GNUSyntax(inst Inst) string {
 
 	case ADD:
 		if inst.Args[1].(Reg) == X0 {
-			op = "mv"
-			args[1] = args[2]
-			args = args[:len(args)-1]
+			if inst.Args[0].(Reg) == X0 {
+				isZihintntl := true
+				switch inst.Args[2].(Reg) {
+				case X2:
+					op = "ntl.p1"
+				case X3:
+					op = "ntl.pall"
+				case X4:
+					op = "ntl.s1"
+				case X5:
+					op = "ntl.all"
+				default:
+					isZihintntl = false
+				}
+				if isZihintntl {
+					args = args[:0]
+				}
+			} else {
+				op = "mv"
+				args[1] = args[2]
+				args = args[:len(args)-1]
+			}
 		}
 
 	case BEQ:

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
@@ -67,6 +67,26 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 		// Atomic instructions have special operand order.
 		args[2], args[1] = args[1], args[2]
 
+	case ADD:
+		if inst.Args[0].(Reg) == X0 && inst.Args[1].(Reg) == X0 {
+			isZihintntl := true
+			switch inst.Args[2].(Reg) {
+			case X2:
+				op = "NTLP1"
+			case X3:
+				op = "NTLPALL"
+			case X4:
+				op = "NTLS1"
+			case X5:
+				op = "NTLALL"
+			default:
+				isZihintntl = false
+			}
+			if isZihintntl {
+				args = args[:0]
+			}
+		}
+
 	case ADDI:
 		if inst.Args[2].(Simm).Imm == 0 {
 			op = "MOV"


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
#50 

`zihintntl` instructions are encoded as `add` instructions, so we recognize the pattern in `plan9x.go`, update the op from `add` to `NTLxx` and clear the args.

tested in my local machine:
```
$ go tool objdump test.out

TEXT main(SB) $GOROOT/src/test.s
  test.s:2              0x2df                   00200033                NTLP1 
  test.s:3              0x2e3                   00300033                NTLPALL 
  test.s:4              0x2e7                   00400033                NTLS1 
  test.s:5              0x2eb                   00500033                NTLALL 
  test.s:6              0x2ef                   00008067                RET
```


<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required