### PR TITLE
cmd/vendor/golang.org/x/arch: fix bug in MemOrder to string

### DIFF
--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
@@ -479,16 +479,16 @@ type MemOrder uint8
 
 func (memOrder MemOrder) String() string {
 	var str string
-	if ((memOrder>>3)<<7)>>7 == 1 {
+	if memOrder&0b1000 == 1 {
 		str += "i"
 	}
-	if ((memOrder>>2)<<7)>>7 == 1 {
+	if memOrder&0b0100 == 1 {
 		str += "o"
 	}
-	if ((memOrder>>1)<<7)>>7 == 1 {
+	if memOrder&0b0010 == 1 {
 		str += "r"
 	}
-	if (memOrder<<7)>>7 == 1 {
+	if memOrder&0b0001 == 1 {
 		str += "w"
 	}
 	return str

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
@@ -479,16 +479,16 @@ type MemOrder uint8
 
 func (memOrder MemOrder) String() string {
 	var str string
-	if memOrder>>3<<7>>7 == 1 {
+	if ((memOrder>>3)<<7)>>7 == 1 {
 		str += "i"
 	}
-	if memOrder>>2<<7>>7 == 1 {
+	if ((memOrder>>2)<<7)>>7 == 1 {
 		str += "o"
 	}
-	if memOrder>>1<<7>>7 == 1 {
+	if ((memOrder>>1)<<7)>>7 == 1 {
 		str += "r"
 	}
-	if memOrder<<7>>7 == 1 {
+	if (memOrder<<7)>>7 == 1 {
 		str += "w"
 	}
 	return str

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
@@ -479,16 +479,16 @@ type MemOrder uint8
 
 func (memOrder MemOrder) String() string {
 	var str string
-	if memOrder<<7>>7 == 1 {
+	if memOrder>>3<<7>>7 == 1 {
 		str += "i"
 	}
-	if memOrder>>1<<7>>7 == 1 {
+	if memOrder>>2<<7>>7 == 1 {
 		str += "o"
 	}
-	if memOrder>>2<<7>>7 == 1 {
+	if memOrder>>1<<7>>7 == 1 {
 		str += "r"
 	}
-	if memOrder>>3<<7>>7 == 1 {
+	if memOrder<<7>>7 == 1 {
 		str += "w"
 	}
 	return str


### PR DESCRIPTION
…extension of riscv64

<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
<img width="1144" height="249" alt="image" src="https://github.com/user-attachments/assets/a314ab8c-8ba4-4416-908e-07d1540b42fd" />

The expected implementation order of IOPW in FENCE is from high to low, but the actual implementation order is from low to high

<img width="361" height="421" alt="image" src="https://github.com/user-attachments/assets/391ba806-06f2-4373-94f1-90494f7029a7" />


<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required