### PR TITLE
cmd/vendor/golang.org/x/arch: add disasm support for the zimop extension of riscv64

### DIFF
--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
@@ -5,6 +5,7 @@
 package riscv64asm
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -255,6 +256,20 @@ func GNUSyntax(inst Inst) string {
 			op = "fneg.s"
 			args = args[:len(args)-1]
 		}
+
+	case MOP_RR_N:
+		num := (inst.Enc >> 30) & 0x1 << 2
+		num |= (inst.Enc >> 27) & 0x1 << 1
+		num |= (inst.Enc >> 26) & 0x1 << 0
+		op = fmt.Sprintf("mop.rr.%d", num)
+
+	case MOP_R_N:
+		num := (inst.Enc >> 30) & 0x1 << 4
+		num |= (inst.Enc >> 27) & 0x1 << 3
+		num |= (inst.Enc >> 26) & 0x1 << 2
+		num |= (inst.Enc >> 21) & 0x1 << 1
+		num |= (inst.Enc >> 20) & 0x1 << 0
+		op = fmt.Sprintf("mop.r.%d", num)
 
 	case JAL:
 		if inst.Args[0].(Reg) == X0 {

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
@@ -274,6 +274,20 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 			args[0], args[1] = args[1], args[0]
 		}
 
+	case MOP_RR_N:
+		num := (inst.Enc >> 30) & 0x1 << 2
+		num |= (inst.Enc >> 27) & 0x1 << 1
+		num |= (inst.Enc >> 26) & 0x1 << 0
+		op = fmt.Sprintf("MOPRR%d", num)
+
+	case MOP_R_N:
+		num := (inst.Enc >> 30) & 0x1 << 4
+		num |= (inst.Enc >> 27) & 0x1 << 3
+		num |= (inst.Enc >> 26) & 0x1 << 2
+		num |= (inst.Enc >> 21) & 0x1 << 1
+		num |= (inst.Enc >> 20) & 0x1 << 0
+		op = fmt.Sprintf("MOPR%d", num)
+
 	case SUB:
 		if inst.Args[1].(Reg) == X0 {
 			op = "NEG"

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
@@ -392,6 +392,8 @@ const (
 	MAXU
 	MIN
 	MINU
+	MOP_RR_N
+	MOP_R_N
 	MUL
 	MULH
 	MULHSU
@@ -843,6 +845,8 @@ var opstr = [...]string{
 	MAXU:           "MAXU",
 	MIN:            "MIN",
 	MINU:           "MINU",
+	MOP_RR_N:       "MOP.RR.N",
+	MOP_R_N:        "MOP.R.N",
 	MUL:            "MUL",
 	MULH:           "MULH",
 	MULHSU:         "MULHSU",
@@ -1677,6 +1681,10 @@ var instFormats = [...]instFormat{
 	{mask: 0xfe00707f, value: 0x0a004033, op: MIN, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// MINU rd, rs1, rs2
 	{mask: 0xfe00707f, value: 0x0a005033, op: MINU, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
+	// MOP.RR.N rd, rs1, rs2
+	{mask: 0xb200707f, value: 0x82004073, op: MOP_RR_N, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
+	// MOP.R.N rd, rs1
+	{mask: 0xb3c0707f, value: 0x81c04073, op: MOP_R_N, args: argTypeList{arg_rd, arg_rs1}},
 	// MUL rd, rs1, rs2
 	{mask: 0xfe00707f, value: 0x02000033, op: MUL, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// MULH rd, rs1, rs2


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required