### PR TITLE
 refactor: cmd/internal/obj/riscv: Zawrs assembly

### DIFF
--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -3891,7 +3891,7 @@ func instructionsForProg(p *obj.Prog) []*instruction {
 		ins.rd, ins.rs1, ins.rs2 = uint32(p.RegTo2), uint32(p.To.Reg), uint32(p.From.Reg)
 
 	case AWRSNTO, AWRSSTO:
-		ins.rd, ins.rs1, ins.imm = REG_ZERO, REG_ZERO, 0
+		ins.rd, ins.rs1, ins.imm = REG_ZERO, REG_ZERO, encode(p.As).csr
 
 	case AECALL, AEBREAK:
 		insEnc := encode(p.As)

--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -3891,12 +3891,7 @@ func instructionsForProg(p *obj.Prog) []*instruction {
 		ins.rd, ins.rs1, ins.rs2 = uint32(p.RegTo2), uint32(p.To.Reg), uint32(p.From.Reg)
 
 	case AWRSNTO, AWRSSTO:
-		ins.rd, ins.rs1 = REG_ZERO, REG_ZERO
-		if ins.as == AWRSNTO {
-			ins.imm = 0x0d
-		} else {
-			ins.imm = 0x1d
-		}
+		ins.rd, ins.rs1, ins.imm = REG_ZERO, REG_ZERO, 0
 
 	case AECALL, AEBREAK:
 		insEnc := encode(p.As)


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
Original implementation: #47 

`iIIencoding` will or `csr` value with `imm` value, and `csr` value are already set to the final `imm` value in `inst.go`, so we don't need to set `imm` in swtich case. 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required