### PR TITLE
runtime: add runtime support for procyield(use PAUSE)

### DIFF
--- a/src/runtime/asm_riscv64.s
+++ b/src/runtime/asm_riscv64.s
@@ -271,6 +271,11 @@ TEXT gogo<>(SB), NOSPLIT|NOFRAME, $0
 
 // func procyield(cycles uint32)
 TEXT runtime·procyield(SB),NOSPLIT,$0-0
+	MOVWU	cycles+0(FP), T0
+yieldloop:
+	PAUSE
+	SUBW	$1, T0
+	BNEZ	T0, yieldloop
 	RET
 
 // Switch to m->g0's stack, call fn(g).


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required