### PR TITLE
runtime: Fix riscv64 spin lock

### DIFF
--- a/src/runtime/asm_riscv64.h
+++ b/src/runtime/asm_riscv64.h
@@ -18,4 +18,5 @@
 #define hasZbs
 #define hasZfa
 #define hasZicond
+#define hasZihintpause
 #endif

--- a/src/runtime/asm_riscv64.h
+++ b/src/runtime/asm_riscv64.h
@@ -18,5 +18,4 @@
 #define hasZbs
 #define hasZfa
 #define hasZicond
-#define hasZihintpause
 #endif

--- a/src/runtime/asm_riscv64.s
+++ b/src/runtime/asm_riscv64.s
@@ -270,9 +270,9 @@ TEXT gogo<>(SB), NOSPLIT|NOFRAME, $0
 	JALR	ZERO, T0
 
 // func procyield(cycles uint32)
-TEXT runtime·procyield<ABIInternal>(SB),NOSPLIT,$0-0
-#ifdef EnableRuntimeSpinlock
-	MOVW	X10, T0
+TEXT runtime·procyield(SB),NOSPLIT,$0-0
+#ifdef EnableRISCV64RuntimeSpinlock
+	MOVWU	cycles+0(FP), T0
 yieldloop:
 	PAUSE
 	SUBW	$1, T0

--- a/src/runtime/asm_riscv64.s
+++ b/src/runtime/asm_riscv64.s
@@ -272,7 +272,7 @@ TEXT gogo<>(SB), NOSPLIT|NOFRAME, $0
 
 // func procyield(cycles uint32)
 TEXT runtime·procyield<ABIInternal>(SB),NOSPLIT,$0-0
-#ifdef hasZihintpause
+#ifdef EnableRuntimeSpinlock
 	MOVW	X10, T0
 yieldloop:
 	PAUSE

--- a/src/runtime/asm_riscv64.s
+++ b/src/runtime/asm_riscv64.s
@@ -5,7 +5,6 @@
 #include "go_asm.h"
 #include "funcdata.h"
 #include "textflag.h"
-#include "asm_riscv64.h"
 
 // func rt0_go()
 TEXT runtime·rt0_go(SB),NOSPLIT|TOPFRAME,$0

--- a/src/runtime/asm_riscv64.s
+++ b/src/runtime/asm_riscv64.s
@@ -5,6 +5,7 @@
 #include "go_asm.h"
 #include "funcdata.h"
 #include "textflag.h"
+#include "asm_riscv64.h"
 
 // func rt0_go()
 TEXT runtime·rt0_go(SB),NOSPLIT|TOPFRAME,$0
@@ -271,11 +272,13 @@ TEXT gogo<>(SB), NOSPLIT|NOFRAME, $0
 
 // func procyield(cycles uint32)
 TEXT runtime·procyield(SB),NOSPLIT,$0-0
+#ifdef hasZihintpause
 	MOVWU	cycles+0(FP), T0
 yieldloop:
 	PAUSE
 	SUBW	$1, T0
 	BNEZ	T0, yieldloop
+#endif
 	RET
 
 // Switch to m->g0's stack, call fn(g).

--- a/src/runtime/asm_riscv64.s
+++ b/src/runtime/asm_riscv64.s
@@ -271,9 +271,9 @@ TEXT gogo<>(SB), NOSPLIT|NOFRAME, $0
 	JALR	ZERO, T0
 
 // func procyield(cycles uint32)
-TEXT runtime·procyield(SB),NOSPLIT,$0-0
+TEXT runtime·procyield<ABIInternal>(SB),NOSPLIT,$0-0
 #ifdef hasZihintpause
-	MOVWU	cycles+0(FP), T0
+	MOVW	X10, T0
 yieldloop:
 	PAUSE
 	SUBW	$1, T0


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
Disable spin lock on riscv64 by default. To use it, set `-D EnableRISCV64RuntimeSpinlock` to `asmflags`, for example:
```
GOARCH=riscv64 GORISCV64=rva23u64 go build -asmflags=all='-D EnableRISCV64RuntimeSpinlock' -o a.out .
```

Also change the abi to `ABIInternal` because it is a runtime function and can pass parameters by registers.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required