### PR TITLE
runtime: add vector implementation of memclrNoHeapPointers for riscv64

### DIFF
--- a/src/runtime/cpuflags.go
+++ b/src/runtime/cpuflags.go
@@ -11,6 +11,11 @@ import (
 
 // Offsets into internal/cpu records for use in assembly.
 const (
+	offsetX86HasAVX    = unsafe.Offsetof(cpu.X86.HasAVX)
+	offsetX86HasAVX2   = unsafe.Offsetof(cpu.X86.HasAVX2)
+	offsetX86HasERMS   = unsafe.Offsetof(cpu.X86.HasERMS)
+	offsetX86HasRDTSCP = unsafe.Offsetof(cpu.X86.HasRDTSCP)
+
 	offsetARMHasIDIVA = unsafe.Offsetof(cpu.ARM.HasIDIVA)
 
 	offsetMIPS64XHasMSA = unsafe.Offsetof(cpu.MIPS64X.HasMSA)
@@ -19,11 +24,6 @@ const (
 	offsetLOONG64HasLASX = unsafe.Offsetof(cpu.Loong64.HasLASX)
 
 	offsetRISCV64HasV = unsafe.Offsetof(cpu.RISCV64.HasV)
-
-	offsetX86HasAVX    = unsafe.Offsetof(cpu.X86.HasAVX)
-	offsetX86HasAVX2   = unsafe.Offsetof(cpu.X86.HasAVX2)
-	offsetX86HasERMS   = unsafe.Offsetof(cpu.X86.HasERMS)
-	offsetX86HasRDTSCP = unsafe.Offsetof(cpu.X86.HasRDTSCP)
 )
 
 var (

--- a/src/runtime/cpuflags.go
+++ b/src/runtime/cpuflags.go
@@ -11,17 +11,19 @@ import (
 
 // Offsets into internal/cpu records for use in assembly.
 const (
-	offsetX86HasAVX    = unsafe.Offsetof(cpu.X86.HasAVX)
-	offsetX86HasAVX2   = unsafe.Offsetof(cpu.X86.HasAVX2)
-	offsetX86HasERMS   = unsafe.Offsetof(cpu.X86.HasERMS)
-	offsetX86HasRDTSCP = unsafe.Offsetof(cpu.X86.HasRDTSCP)
-
 	offsetARMHasIDIVA = unsafe.Offsetof(cpu.ARM.HasIDIVA)
 
 	offsetMIPS64XHasMSA = unsafe.Offsetof(cpu.MIPS64X.HasMSA)
 
 	offsetLOONG64HasLSX  = unsafe.Offsetof(cpu.Loong64.HasLSX)
 	offsetLOONG64HasLASX = unsafe.Offsetof(cpu.Loong64.HasLASX)
+
+	offsetRISCV64HasV = unsafe.Offsetof(cpu.RISCV64.HasV)
+
+	offsetX86HasAVX    = unsafe.Offsetof(cpu.X86.HasAVX)
+	offsetX86HasAVX2   = unsafe.Offsetof(cpu.X86.HasAVX2)
+	offsetX86HasERMS   = unsafe.Offsetof(cpu.X86.HasERMS)
+	offsetX86HasRDTSCP = unsafe.Offsetof(cpu.X86.HasRDTSCP)
 )
 
 var (

--- a/src/runtime/memclr_riscv64.s
+++ b/src/runtime/memclr_riscv64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#include "asm_riscv64.h"
+#include "go_asm.h"
 #include "textflag.h"
 
 // See memclrNoHeapPointers Go doc for important implementation constraints.
@@ -15,6 +17,30 @@ TEXT runtime·memclrNoHeapPointers<ABIInternal>(SB),NOSPLIT,$0-16
 	MOV	$8, X9
 	BLT	X11, X9, check4
 
+#ifndef hasV
+	MOVB	internal∕cpu·RISCV64+const_offsetRISCV64HasV(SB), X5
+	BEQZ	X5, memclr_scalar
+#endif
+
+	// Use vector if not 8 byte aligned.
+	AND	$7, X10, X5
+	BNEZ	X5, vector_loop
+
+	// Use scalar if 8 byte aligned and <= 64 bytes.
+	SUB	$64, X11, X6
+	BLEZ	X6, aligned
+
+	PCALIGN	$16
+vector_loop:
+	VSETVLI	X11, E8, M8, TA, MA, X5
+	VMVVI	$0, V8
+	VSE8V	V8, (X10)
+	ADD	X5, X10
+	SUB	X5, X11
+	BNEZ	X11, vector_loop
+	RET
+
+memclr_scalar:
 	// Check alignment
 	AND	$7, X10, X5
 	BEQZ	X5, aligned
@@ -37,6 +63,8 @@ aligned:
 	BLT	X11, X9, zero16
 	MOV	$64, X9
 	BLT	X11, X9, zero32
+
+	PCALIGN	$16
 loop64:
 	MOV	ZERO, 0(X10)
 	MOV	ZERO, 8(X10)

--- a/src/runtime/memclr_riscv64.s
+++ b/src/runtime/memclr_riscv64.s
@@ -34,10 +34,13 @@ TEXT runtime·memclrNoHeapPointers<ABIInternal>(SB),NOSPLIT,$0-16
 vector_loop:
 	VSETVLI	X11, E8, M8, TA, MA, X5
 	VMVVI	$0, V8
+fixed_vl_loop:
 	VSE8V	V8, (X10)
 	ADD	X5, X10
 	SUB	X5, X11
-	BNEZ	X11, vector_loop
+	BGE	X11, X5, fixed_vl_loop // remaining >= current VL, reuse current VL
+	BEQZ	X11, done
+	BGTZ	X11, vector_loop		// remaining < current VL, reset VL
 	RET
 
 memclr_scalar:


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
https://go-review.googlesource.com/c/go/+/648857/11

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required