### PR TITLE
cmd/internal/obj/riscv: add codegen support for zcb instrction

### DIFF
--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -4008,6 +4008,21 @@ func (ins *instruction) compress() {
 			ins.as = ACLD
 		}
 
+	case ALH:
+		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && isScaledImmU(ins.imm, 2, 2) {
+			ins.as = ACLH
+		}
+
+	case ALBU:
+		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && immUFits(ins.imm, 2) == nil{
+			ins.as = ACLBU
+		}
+
+	case ALHU:
+		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && isScaledImmU(ins.imm, 2, 2) {
+			ins.as = ACLHU
+		}
+
 	case AFLD:
 		if ins.rs1 == REG_SP && isScaledImmU(ins.imm, 9, 8) {
 			ins.as, ins.rs1, ins.rs2 = ACFLDSP, obj.REG_NONE, ins.rs1
@@ -4027,6 +4042,16 @@ func (ins *instruction) compress() {
 			ins.as, ins.rs1, ins.rs2 = ACSDSP, obj.REG_NONE, ins.rs1
 		} else if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && isScaledImmU(ins.imm, 8, 8) {
 			ins.as, ins.rd, ins.rs1, ins.rs2 = ACSD, obj.REG_NONE, ins.rd, ins.rs1
+		}
+
+	case ASB:
+		if isIntPrimeReg(ins.rs1) && isIntPrimeReg(ins.rs2) && immUFits(ins.imm, 2) == nil {
+			ins.as, ins.rd, ins.rs1, ins.rs2 = ACSB, obj.REG_NONE, ins.rd, ins.rs1
+		}
+
+	case ASH:
+		if isIntPrimeReg(ins.rs1) && isIntPrimeReg(ins.rs2) && isScaledImmU(ins.imm, 2, 2) {
+			ins.as, ins.rd, ins.rs1, ins.rs2 = ACSH, obj.REG_NONE, ins.rd, ins.rs1
 		}
 
 	case AFSD:
@@ -4079,6 +4104,28 @@ func (ins *instruction) compress() {
 	case AANDI:
 		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && immIFits(ins.imm, 6) == nil {
 			ins.as = ACANDI
+		} else if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1  && ins.imm == 0xff {
+			ins.as = ACZEXTB
+		}
+
+	case ASEXTB:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 {
+			ins.as = ACSEXTB
+		}
+
+	case ASEXTH:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 {
+			ins.as = ACSEXTH
+		}
+
+	case AZEXTH:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 {
+			ins.as = ACZEXTH
+		}
+
+	case AADDUW:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && ins.rs2 == REG_X0 {
+			ins.as, ins.rs2 = ACZEXTW, obj.REG_NONE
 		}
 
 	case AADD:
@@ -4088,6 +4135,11 @@ func (ins *instruction) compress() {
 			ins.as, ins.rs1, ins.rs2 = ACADD, ins.rs2, ins.rs1
 		} else if ins.rd != REG_X0 && ins.rs1 == REG_X0 && ins.rs2 != REG_X0 {
 			ins.as = ACMV
+		}
+
+	case AMUL:
+		if ins.rd == ins.rs1 && isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs2) {
+			ins.as = ACMUL
 		}
 
 	case AADDW:
@@ -4126,6 +4178,11 @@ func (ins *instruction) compress() {
 			ins.as = ACXOR
 		} else if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && ins.rd == ins.rs2 {
 			ins.as, ins.rs1, ins.rs2 = ACXOR, ins.rs2, ins.rs1
+		}
+
+	case AXORI:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && ins.imm == -1 {
+			ins.as = ACNOT
 		}
 
 	case AEBREAK:


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required