### PR TITLE
cmd/vendor/golang.org/x/arch: add disasm support for the zihintpause extension of riscv64

### DIFF
--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
@@ -266,6 +266,12 @@ func GNUSyntax(inst Inst) string {
 			inst.Args[1].(MemOrder).String() == "iorw" {
 			args = nil
 		}
+		//PAUSE is encoded as a FENCE instruction with pred=W, succ=0
+		if inst.Args[0].(MemOrder).String() == "w" &&
+			inst.Args[1].(MemOrder).String() == "" {
+			op = "pause"
+			args = nil
+		}
 
 	case FSGNJX_D:
 		if inst.Args[1].(Reg) == inst.Args[2].(Reg) {

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
@@ -214,6 +214,11 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 
 	// Fence instruction in plan9 doesn't have any operands.
 	case FENCE:
+		//PAUSE is encoded as a FENCE instruction with pred=W, succ=0
+		if inst.Args[0].(MemOrder).String() == "w" &&
+			inst.Args[1].(MemOrder).String() == "" {
+			op = "PAUSE"
+		}
 		args = nil
 
 	case FMADD_D, FMADD_H, FMADD_Q, FMADD_S, FMSUB_D, FMSUB_H,


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions

```
TEXT asmtest(SB),$0-24
PAUSE
```

disasm for “go tool objdump --gnu -S pausetest.o”

`0x2e1                 0100000f                PAUSE                                // pause`

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required