### PR TITLE
enable condselect and add cost estimaition in branchelim.go

### DIFF
--- a/src/cmd/compile/internal/ssa/branchelim.go
+++ b/src/cmd/compile/internal/ssa/branchelim.go
@@ -6,6 +6,7 @@ package ssa
 
 import (
 	"cmd/internal/src"
+	"internal/buildcfg"
 )
 
 // branchelim tries to eliminate branches by
@@ -26,6 +27,10 @@ func branchelim(f *Func) {
 	switch f.Config.arch {
 	case "arm64", "ppc64le", "ppc64", "amd64", "wasm", "loong64":
 		// implemented
+	case "riscv64":
+		if buildcfg.GORISCV64 < 23 {
+			return
+		}
 	default:
 		return
 	}
@@ -160,6 +165,10 @@ func elimIf(f *Func, loadAddr *sparseSet, dom *Block) bool {
 	const maxfuseinsts = 2
 
 	if len(simple.Values) > maxfuseinsts || !canSpeculativelyExecute(simple) {
+		return false
+	}
+
+	if !shouldElimIf(simple, post, dom, f.Config.arch) {
 		return false
 	}
 
@@ -344,7 +353,7 @@ func elimIfElse(f *Func, loadAddr *sparseSet, b *Block) bool {
 	}
 
 	// Don't generate CondSelects if branch is cheaper.
-	if !shouldElimIfElse(no, yes, post, f.Config.arch) {
+	if !shouldElimIfElse(no, yes, post, b.Controls[0], f.Config.arch) {
 		return false
 	}
 
@@ -393,9 +402,57 @@ func elimIfElse(f *Func, loadAddr *sparseSet, b *Block) bool {
 	return true
 }
 
+// shouldElimIf reports whether estimated cost of eliminating a one-way branch
+// is lower than threshold. This is similar to shouldElimIfElse but for elimIf.
+func shouldElimIf(simple, post, dom *Block, arch string) bool {
+	switch arch {
+	default:
+		return true
+	case "riscv64":
+		// Use zicond when: zero/const select (1 inst), conditional arithmetic (2 inst),
+		// multiple phis, or unpredictable branches. Otherwise prefer branches (2 inst vs 4 inst).
+		phi := 0
+		hasConditionalArithmetic := false
+		hasZeroOrConstSelect := false
+
+		for _, v := range post.Values {
+			if v.Op == OpPhi {
+				phi++
+				if isZeroOrConstSelectForElimIf(v, simple, post) {
+					hasZeroOrConstSelect = true
+				}
+				if isConditionalArithmeticCandidateForElimIf(v, simple, post) {
+					hasConditionalArithmetic = true
+				}
+			}
+		}
+		if hasZeroOrConstSelect || hasConditionalArithmetic {
+			return true
+		}
+		if phi == 1 {
+			if isLikelyUnpredictableBranch(dom.Controls[0]) {
+				return true
+			}
+			if isInequalityOp(dom.Controls[0]) {
+				return false
+			}
+			if len(simple.Values) == 1 {
+				op := simple.Values[0].Op
+				if op == OpNeg64 || op == OpNeg32 || op == OpCom64 || op == OpCom32 ||
+					op == OpAdd64 || op == OpAdd32 || op == OpSub64 || op == OpSub32 {
+					return true
+				}
+			}
+			return false
+		}
+		return phi >= 2
+	}
+	// For other architectures, default case handles eliminating branches
+}
+
 // shouldElimIfElse reports whether estimated cost of eliminating branch
 // is lower than threshold.
-func shouldElimIfElse(no, yes, post *Block, arch string) bool {
+func shouldElimIfElse(no, yes, post *Block, cond *Value, arch string) bool {
 	switch arch {
 	default:
 		return true
@@ -423,7 +480,262 @@ func shouldElimIfElse(no, yes, post *Block, arch string) bool {
 			cost += other * 1
 		}
 		return cost < maxcost
+	case "riscv64":
+		// Use zicond when: zero/const select (1 inst), conditional arithmetic (2 inst),
+		// multiple phis, or unpredictable branches. Otherwise prefer branches (2 inst vs 4 inst).
+		phi := 0
+		hasConditionalArithmetic := false
+		hasZeroOrConstSelect := false
+		for _, v := range post.Values {
+			if v.Op == OpPhi {
+				phi++
+				if isZeroOrConstSelect(v, no, yes) {
+					hasZeroOrConstSelect = true
+				}
+				if isConditionalArithmeticCandidate(v, no, yes) {
+					hasConditionalArithmetic = true
+				}
+			}
+		}
+		if hasZeroOrConstSelect || hasConditionalArithmetic {
+			return true
+		}
+		if phi == 1 {
+			if isLikelyUnpredictableBranch(cond) {
+				return true
+			}
+			if isInequalityOp(cond) {
+				return false
+			}
+			hasSimpleOp := false
+			for _, block := range []*Block{yes, no} {
+				if len(block.Values) == 1 {
+					op := block.Values[0].Op
+					if op == OpNeg64 || op == OpNeg32 || op == OpCom64 || op == OpCom32 ||
+						op == OpAdd64 || op == OpAdd32 || op == OpSub64 || op == OpSub32 ||
+						op == OpOr64 || op == OpOr32 || op == OpXor64 || op == OpXor32 {
+						hasSimpleOp = true
+						break
+					}
+				}
+			}
+			if hasSimpleOp {
+				return true
+			}
+			return false
+		}
+		return phi >= 2
 	}
+}
+
+// isConditionalArithmeticCandidateForElimIf checks if a phi in elimIf represents
+// conditional arithmetic (e.g., if cond { a += b } else { a = a }).
+func isConditionalArithmeticCandidateForElimIf(v *Value, simple, post *Block) bool {
+	if len(v.Args) != 2 {
+		return false
+	}
+	// Check if one arg is an arithmetic operation from simple block
+	// and the other arg is the base value (first operand of the arithmetic op)
+	for i, arg := range v.Args {
+		if arg.Block == simple && isArithmeticOp(arg.Op) {
+			// Check if the arithmetic operation has at least 2 operands
+			if len(arg.Args) >= 2 {
+				baseValue := arg.Args[0] // First operand is typically the base value
+				// Check if the other phi arg matches the base value
+				otherArg := v.Args[1-i]
+				if baseValue == otherArg {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isConditionalArithmeticCandidate checks if a phi represents conditional arithmetic
+// (e.g., if cond { a += b } else { a = a }). Optimized to 2 instructions by RISCV64.rules.
+func isConditionalArithmeticCandidate(v *Value, no, yes *Block) bool {
+	if len(v.Args) != 2 {
+		return false
+	}
+	// Check if one arg is an arithmetic operation from no/yes blocks
+	// and the other arg is the base value (first operand of the arithmetic op)
+	for i, arg := range v.Args {
+		if (arg.Block == no || arg.Block == yes) && isArithmeticOp(arg.Op) {
+			// Check if the arithmetic operation has at least 2 operands
+			if len(arg.Args) >= 2 {
+				baseValue := arg.Args[0] // First operand is typically the base value
+				// Check if the other phi arg matches the base value
+				otherArg := v.Args[1-i]
+				if baseValue == otherArg {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isArithmeticOp checks if an operation can be optimized by conditional arithmetic rules.
+func isArithmeticOp(op Op) bool {
+	switch op {
+	case OpAdd64, OpAdd32, OpAdd16, OpAdd8,
+		OpSub64, OpSub32, OpSub16, OpSub8,
+		OpOr64, OpOr32, OpOr16, OpOr8,
+		OpXor64, OpXor32, OpXor16, OpXor8,
+		OpAdd32F, OpAdd64F,
+		OpSub32F, OpSub64F:
+		return true
+	}
+	return false
+}
+
+func isZeroOrConstSelect(v *Value, no, yes *Block) bool {
+	if len(v.Args) != 2 {
+		return false
+	}
+	for i, arg := range v.Args {
+		otherArg := v.Args[1-i]
+		if arg.isGenericIntConst() && arg.AuxInt == 0 {
+			if otherArg.isGenericIntConst() && otherArg.AuxInt != 0 {
+				return true
+			}
+			if otherArg.Block == no || otherArg.Block == yes {
+				return true
+			}
+		}
+		if otherArg.isGenericIntConst() && otherArg.AuxInt == 0 {
+			if arg.isGenericIntConst() && arg.AuxInt != 0 {
+				return true
+			}
+			if arg.Block == no || arg.Block == yes {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isZeroOrConstSelectForElimIf(v *Value, simple, post *Block) bool {
+	if len(v.Args) != 2 || len(post.Preds) != 2 {
+		return false
+	}
+	var simpleArgIdx int = -1
+	for i, pred := range post.Preds {
+		if pred.Block() == simple {
+			simpleArgIdx = i
+			break
+		}
+	}
+	if simpleArgIdx == -1 {
+		return false
+	}
+	simpleArg := v.Args[simpleArgIdx]
+	otherArgIdx := 1 - simpleArgIdx
+	otherArg := v.Args[otherArgIdx]
+
+	if otherArg.isGenericIntConst() && otherArg.AuxInt == 0 {
+		if simpleArg.isGenericIntConst() && simpleArg.AuxInt != 0 {
+			return true
+		}
+		if simpleArg.Block == simple {
+			return true
+		}
+	}
+
+	if simpleArg.isGenericIntConst() && simpleArg.AuxInt == 0 {
+		if otherArg.isGenericIntConst() && otherArg.AuxInt != 0 {
+			return true
+		}
+		if otherArg.Block != simple {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isInequalityOp checks if a branch condition is an inequality comparison (<, >, <=, >=).
+// Inequalities use efficient branch instructions (2 inst) vs zicond (4 inst).
+// Note: Does not include ==/!= which may benefit from zicond when unpredictable.
+func isInequalityOp(cond *Value) bool {
+	if cond == nil {
+		return false
+	}
+	switch cond.Op {
+	case OpLess64, OpLess32, OpLess16, OpLess8,
+		OpLess64U, OpLess32U, OpLess16U, OpLess8U,
+		OpLeq64, OpLeq32, OpLeq16, OpLeq8,
+		OpLeq64U, OpLeq32U, OpLeq16U, OpLeq8U:
+		return true
+	}
+	switch cond.Op {
+	case OpRISCV64SLT, OpRISCV64SLTU, OpRISCV64SLTI, OpRISCV64SLTIU:
+		return true
+	}
+	return false
+}
+
+// isLikelyUnpredictableBranch checks if a branch condition is likely unpredictable
+// (XOR, bit manipulation, hash-like). Unpredictable branches benefit from zicond
+func isLikelyUnpredictableBranch(cond *Value) bool {
+	if cond == nil {
+		return false
+	}
+
+	var checkUnpredictable func(*Value, int) bool
+	checkUnpredictable = func(v *Value, depth int) bool {
+		if v == nil || depth > 5 {
+			return false
+		}
+
+		switch v.Op {
+		case OpXor64, OpXor32, OpXor16, OpXor8:
+			return true
+
+		case OpAnd64, OpAnd32, OpAnd16, OpAnd8:
+			for _, arg := range v.Args {
+				if arg.Op == OpConst64 || arg.Op == OpConst32 || arg.Op == OpConst16 || arg.Op == OpConst8 {
+					mask := arg.AuxInt
+					if mask == 1 || mask == 3 || mask == 7 || mask == 15 {
+						for _, otherArg := range v.Args {
+							if otherArg != arg && checkUnpredictable(otherArg, depth+1) {
+								return true
+							}
+						}
+					}
+				}
+			}
+			for _, arg := range v.Args {
+				if checkUnpredictable(arg, depth+1) {
+					return true
+				}
+			}
+
+		case OpNeq64, OpNeq32, OpNeq16, OpNeq8,
+			OpEq64, OpEq32, OpEq16, OpEq8:
+			for _, arg := range v.Args {
+				if checkUnpredictable(arg, depth+1) {
+					return true
+				}
+			}
+
+		case OpRsh64Ux64, OpRsh32Ux64, OpRsh16Ux64, OpRsh8Ux64,
+			OpRsh64Ux32, OpRsh32Ux32, OpRsh16Ux32, OpRsh8Ux32:
+			return depth > 0
+
+		case OpOr64, OpOr32, OpOr16, OpOr8:
+			for _, arg := range v.Args {
+				if checkUnpredictable(arg, depth+1) {
+					return true
+				}
+			}
+		}
+
+		return false
+	}
+
+	return checkUnpredictable(cond, 0)
 }
 
 // canSpeculativelyExecute reports whether every value in the block can


### PR DESCRIPTION
Previously, to prevent performance regressions caused by zicond, we kept condSelect globally disabled for riscv64, and only enable it specifically for this one intrinsic (ConstantTimeSelect). To make better use of zicond for optimizing hard-to-predict branch efficiency, I added cost estimation to ensure zicond is generated only in beneficial cases, such as conditional arithmetic operations and unpredictable branches.