### PR TITLE
Fix: fix prefetch disassmbly and assembly

### DIFF
--- a/src/cmd/asm/internal/asm/testdata/riscv64.s
+++ b/src/cmd/asm/internal/asm/testdata/riscv64.s
@@ -312,9 +312,8 @@ start:
 	// 19.6.3: Cache-Block Prefetch Instructions
 	PREFETCHI 448(X5)					// 13e0021c
 	PREFETCHI -64(X5)					// 13e002fc
-	PREFETCHI 453(X5)					// 13e0021c
-	PREFETCHR 449(X5)					// 13e0121c
-	PREFETCHW 451(X5)					// 13e0321c
+	PREFETCHR 448(X5)					// 13e0121c
+	PREFETCHW 448(X5)					// 13e0321c
 
 	// 20.5: Single-Precision Load and Store Instructions
 	FLW	(X5), F0				// 07a00200

--- a/src/cmd/asm/internal/asm/testdata/riscv64error.s
+++ b/src/cmd/asm/internal/asm/testdata/riscv64error.s
@@ -81,6 +81,11 @@ TEXT errors(SB),$0
 	SD	X5, 4294967296(X6)		// ERROR "constant 4294967296 too large"
 	FNES	F1, (X5)			// ERROR "needs an integer register output"
 
+	// 19.6.3: Cache-Block Prefetch Instructions
+	PREFETCHI -65(X5)					// ERROR "The imm[4:0] of PREFETCH must equal 0b00000"
+	PREFETCHR 449(X5)					// ERROR "The imm[4:0] of PREFETCH must equal 0b00000"
+	PREFETCHW 451(X5)					// ERROR "The imm[4:0] of PREFETCH must equal 0b00000"
+
 	//
 	// "V" Standard Extension for Vector Operations, Version 1.0
 	//

--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -248,6 +248,12 @@ func progedit(ctxt *obj.Link, p *obj.Prog, newprog obj.ProgAlloc) {
 		}
 
 	case APREFETCHI, APREFETCHR, APREFETCHW:
+		low5bits := p.From.Offset & 0b11111
+		if low5bits != 0 {
+			p.Ctxt.Diag("%v: The imm[4:0] of PREFETCH must equal 0b00000", p)
+			return
+		}
+
 		p.From.Offset = p.From.Offset &^ 0b11111
 		switch p.As {
 		case APREFETCHI:

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
@@ -69,7 +69,7 @@ func GNUSyntax(inst Inst) string {
 
 		if inst.Op == ORI && inst.Args[0].(Reg) == X0 {
 			imm := inst.Args[2].(Simm).Imm
-			switch imm & ((1 << 5) - 1) {
+			switch imm & 0b11111 {
 			case 0:
 				op = "prefetch.i"
 			case 1:
@@ -79,7 +79,7 @@ func GNUSyntax(inst Inst) string {
 			}
 			// compared to ORI, the lowest 5 bits of imm in PREFETCH should be zeros
 			simm := inst.Args[2].(Simm)
-			simm.Imm = simm.Imm & 0b111111100000
+			simm.Imm = simm.Imm &^ 0b11111
 			if imm == 0 {
 				args[0] = fmt.Sprintf("(X%d)", inst.Args[1].(Reg))
 			} else {

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/gnu.go
@@ -77,10 +77,13 @@ func GNUSyntax(inst Inst) string {
 			case 3:
 				op = "prefetch.w"
 			}
+			// compared to ORI, the lowest 5 bits of imm in PREFETCH should be zeros
+			simm := inst.Args[2].(Simm)
+			simm.Imm = simm.Imm & 0b111111100000
 			if imm == 0 {
 				args[0] = fmt.Sprintf("(X%d)", inst.Args[1].(Reg))
 			} else {
-				args[0] = fmt.Sprintf("%s(X%d)", inst.Args[2].(Simm).String(), inst.Args[1].(Reg))
+				args[0] = fmt.Sprintf("%s(X%d)", simm.String(), inst.Args[1].(Reg))
 			}
 			args = args[:len(args)-2]
 		}

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
@@ -310,7 +310,7 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 	case ORI:
 		if inst.Args[0].(Reg) == X0 {
 			imm := inst.Args[2].(Simm).Imm
-			switch imm & ((1 << 5) - 1) {
+			switch imm & 0b11111 {
 			case 0:
 				op = "PREFETCHI"
 			case 1:
@@ -320,7 +320,7 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 			}
 			// compared to ORI, the lowest 5 bits of imm in PREFETCH should be zeros
 			simm := inst.Args[2].(Simm)
-			simm.Imm = simm.Imm & 0b111111100000
+			simm.Imm = simm.Imm &^ 0b11111
 			args[0] = plan9Arg(&inst, pc, symname, RegOffset{inst.Args[1].(Reg), simm})
 			args = args[:len(args)-2]
 		}

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/plan9x.go
@@ -318,7 +318,10 @@ func GoSyntax(inst Inst, pc uint64, symname func(uint64) (string, uint64), text 
 			case 3:
 				op = "PREFETCHW"
 			}
-			args[0] = plan9Arg(&inst, pc, symname, RegOffset{inst.Args[1].(Reg), inst.Args[2].(Simm)})
+			// compared to ORI, the lowest 5 bits of imm in PREFETCH should be zeros
+			simm := inst.Args[2].(Simm)
+			simm.Imm = simm.Imm & 0b111111100000
+			args[0] = plan9Arg(&inst, pc, symname, RegOffset{inst.Args[1].(Reg), simm})
 			args = args[:len(args)-2]
 		}
 


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
For prefetch instructions, in #57 we support assembly and in #58  we support disassembly. But the previous implementation **didn't check the offset value**, which must be **a multiple of 32**:
> A prefetch.r instruction indicates to hardware that the cache block whose effective address is the
sum of the base address specified in rs1 and the sign-extended offset encoded in imm[11:0], **where
imm[4:0] equals 0b00000**

<img width="1246" height="119" alt="image" src="https://github.com/user-attachments/assets/c387ec17-18ac-4aeb-8c6c-cc092fa5f8f2" />

So in this PR we add check for offset value. And for disassembly, we also make sure the lowest 5 bits of  PREFETCH offset is zero.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required