### PR TITLE
cmd/compile/internal/ssa: add prefetch codegen rules

### DIFF
--- a/src/cmd/compile/internal/riscv64/ssa.go
+++ b/src/cmd/compile/internal/riscv64/ssa.go
@@ -880,6 +880,19 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 	case ssa.OpClobber, ssa.OpClobberReg:
 		// TODO: implement for clobberdead experiment. Nop is ok for now.
 
+	case ssa.OpRISCV64PREFETCH:
+		p := s.Prog(riscv.APREFETCHR)
+		p.From.Offset = v.AuxInt
+		p.From.Reg = v.Args[0].Reg()
+		p.From.Type = obj.TYPE_MEM
+
+	case ssa.OpRISCV64PREFETCHNT:
+		s.Prog(riscv.ANTLALL)
+		p := s.Prog(riscv.APREFETCHR)
+		p.From.Offset = v.AuxInt
+		p.From.Reg = v.Args[0].Reg()
+		p.From.Type = obj.TYPE_MEM
+
 	default:
 		v.Fatalf("Unhandled op %v", v.Op)
 	}

--- a/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
@@ -829,3 +829,6 @@
 (OR (CZEROEQZ x:(ANDI <t> [c] z) cond) y:(CZERONEZ z cond)) => (OR x y)
 (OR (CZERONEZ <t> ((ADDI|ORI|XORI) [c] x) cond) (CZEROEQZ <t> x cond)) => ((ADD|OR|XOR) x (CZERONEZ <t> (MOVDconst [c]) cond))
 (OR (CZEROEQZ <t> ((ADDI|ORI|XORI) [c] x) cond) (CZERONEZ <t> x cond)) => ((ADD|OR|XOR) x (CZEROEQZ <t> (MOVDconst [c]) cond))
+
+(PrefetchCache ...)   => (PREFETCH ...)
+(PrefetchCacheStreamed ...) => (PREFETCHNT ...)

--- a/src/cmd/compile/internal/ssa/_gen/RISCV64Ops.go
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64Ops.go
@@ -140,6 +140,7 @@ func init() {
 		call        = regInfo{clobbers: callerSave}
 		callClosure = regInfo{inputs: []regMask{gpspMask, regCtxt, 0}, clobbers: callerSave}
 		callInter   = regInfo{inputs: []regMask{gpMask}, clobbers: callerSave}
+		prefreg     = regInfo{inputs: []regMask{gpspsbMask}}
 	)
 
 	RISCV64ops := []opData{
@@ -501,6 +502,9 @@ func init() {
 		// RISC-V Integer Conditional (Zicond) operations extension
 		{name: "CZEROEQZ", argLength: 2, reg: gp21, asm: "CZEROEQZ"},
 		{name: "CZERONEZ", argLength: 2, reg: gp21, asm: "CZERONEZ"},
+
+		{name: "PREFETCH", argLength: 2, reg: prefreg, asm: "PREFETCHR", hasSideEffects: true},
+		{name: "PREFETCHNT", argLength: 2, reg: prefreg, asm: "PREFETCHR", hasSideEffects: true},
 	}
 
 	RISCV64blocks := []blockData{

--- a/src/cmd/compile/internal/ssa/opGen.go
+++ b/src/cmd/compile/internal/ssa/opGen.go
@@ -2640,6 +2640,8 @@ const (
 	OpRISCV64LoweredFMAXD
 	OpRISCV64CZEROEQZ
 	OpRISCV64CZERONEZ
+	OpRISCV64PREFETCH
+	OpRISCV64PREFETCHNT
 
 	OpS390XFADDS
 	OpS390XFADD
@@ -35625,6 +35627,28 @@ var opcodeTable = [...]opInfo{
 			},
 			outputs: []outputInfo{
 				{0, 1006632944}, // X5 X6 X7 X8 X9 X10 X11 X12 X13 X14 X15 X16 X17 X18 X19 X20 X21 X22 X23 X24 X25 X26 X28 X29 X30
+			},
+		},
+	},
+	{
+		name:           "PREFETCH",
+		argLen:         2,
+		hasSideEffects: true,
+		asm:            riscv.APREFETCHR,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{0, 9223372037861408754}, // SP X5 X6 X7 X8 X9 X10 X11 X12 X13 X14 X15 X16 X17 X18 X19 X20 X21 X22 X23 X24 X25 X26 X28 X29 X30 SB
+			},
+		},
+	},
+	{
+		name:           "PREFETCHNT",
+		argLen:         2,
+		hasSideEffects: true,
+		asm:            riscv.APREFETCHR,
+		reg: regInfo{
+			inputs: []inputInfo{
+				{0, 9223372037861408754}, // SP X5 X6 X7 X8 X9 X10 X11 X12 X13 X14 X15 X16 X17 X18 X19 X20 X21 X22 X23 X24 X25 X26 X28 X29 X30 SB
 			},
 		},
 	},

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64.go
@@ -499,6 +499,12 @@ func rewriteValueRISCV64(v *Value) bool {
 		return true
 	case OpPopCount8:
 		return rewriteValueRISCV64_OpPopCount8(v)
+	case OpPrefetchCache:
+		v.Op = OpRISCV64PREFETCH
+		return true
+	case OpPrefetchCacheStreamed:
+		v.Op = OpRISCV64PREFETCHNT
+		return true
 	case OpPubBarrier:
 		v.Op = OpRISCV64LoweredPubBarrier
 		return true

--- a/src/cmd/compile/internal/ssagen/intrinsics.go
+++ b/src/cmd/compile/internal/ssagen/intrinsics.go
@@ -234,9 +234,9 @@ func initIntrinsics(cfg *intrinsicBuildConfig) {
 	// Make Prefetch intrinsics for supported platforms
 	// On the unsupported platforms stub function will be eliminated
 	addF("internal/runtime/sys", "Prefetch", makePrefetchFunc(ssa.OpPrefetchCache),
-		sys.AMD64, sys.ARM64, sys.Loong64, sys.PPC64)
+		sys.AMD64, sys.ARM64, sys.Loong64, sys.PPC64, sys.RISCV64)
 	addF("internal/runtime/sys", "PrefetchStreamed", makePrefetchFunc(ssa.OpPrefetchCacheStreamed),
-		sys.AMD64, sys.ARM64, sys.Loong64, sys.PPC64)
+		sys.AMD64, sys.ARM64, sys.Loong64, sys.PPC64, sys.RISCV64)
 
 	/******** internal/runtime/atomic ********/
 	type atomicOpEmitter func(s *state, n *ir.CallExpr, args []*ssa.Value, op ssa.Op, typ types.Kind, needReturn bool)

--- a/src/cmd/compile/internal/ssagen/intrinsics_test.go
+++ b/src/cmd/compile/internal/ssagen/intrinsics_test.go
@@ -1137,6 +1137,8 @@ var wantIntrinsics = map[testIntrinsicKey]struct{}{
 	{"riscv64", "internal/runtime/sys", "Len64"}:                       struct{}{},
 	{"riscv64", "internal/runtime/sys", "Len8"}:                        struct{}{},
 	{"riscv64", "internal/runtime/sys", "OnesCount64"}:                 struct{}{},
+	{"riscv64", "internal/runtime/sys", "Prefetch"}:                    struct{}{},
+	{"riscv64", "internal/runtime/sys", "PrefetchStreamed"}:            struct{}{},
 	{"riscv64", "internal/runtime/sys", "TrailingZeros32"}:             struct{}{},
 	{"riscv64", "internal/runtime/sys", "TrailingZeros64"}:             struct{}{},
 	{"riscv64", "internal/runtime/sys", "TrailingZeros8"}:              struct{}{},

--- a/src/internal/runtime/sys/intrinsics.go
+++ b/src/internal/runtime/sys/intrinsics.go
@@ -197,6 +197,8 @@ func Bswap32(x uint32) uint32 {
 // AMD64: Produce PREFETCHT0 instruction
 //
 // ARM64: Produce PRFM instruction with PLDL1KEEP option
+//
+// RISCV64: Produce PREFETCHR instruction
 func Prefetch(addr uintptr) {}
 
 // PrefetchStreamed prefetches data from memory addr, with a hint that this data is being streamed.
@@ -205,6 +207,8 @@ func Prefetch(addr uintptr) {}
 // AMD64: Produce PREFETCHNTA instruction
 //
 // ARM64: Produce PRFM instruction with PLDL1STRM option
+//
+// RISCV64: Produce PREFETCHR instruction followed by NTLALL instruction
 func PrefetchStreamed(addr uintptr) {}
 
 // GetCallerPC returns the program counter (PC) of its caller's caller.


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
This pr add codegen rules for prefetch instructions in Zicbop extension: convert `Prefetch` function calls to prefetch hint.

The codegen rules is applied in riscv ISA **without profiles required**. Because the prefetch hint equals `ori` instructions with rd set as x0, nothing will hapen in hardwares which doesn't support Zicbop .

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required