### PR TITLE
Fix: fix disassembler memorder string bug

### DIFF
--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/inst.go
@@ -525,16 +525,16 @@ type MemOrder uint8
 
 func (memOrder MemOrder) String() string {
 	var str string
-	if memOrder&0b1000 == 1 {
+	if memOrder&0b1000 != 0 {
 		str += "i"
 	}
-	if memOrder&0b0100 == 1 {
+	if memOrder&0b0100 != 0 {
 		str += "o"
 	}
-	if memOrder&0b0010 == 1 {
+	if memOrder&0b0010 != 0 {
 		str += "r"
 	}
-	if memOrder&0b0001 == 1 {
+	if memOrder&0b0001 != 0 {
 		str += "w"
 	}
 	return str


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
Fix code logic bug.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required