### PR TITLE
cmd/compile/internal/ssa: enable unalign memory access optimization on riscv64

### DIFF
--- a/src/cmd/compile/internal/ssa/config.go
+++ b/src/cmd/compile/internal/ssa/config.go
@@ -337,6 +337,7 @@ func NewConfig(arch string, types Types, ctxt *obj.Link, optimize, softfloat boo
 		c.floatParamRegs = paramFloatRegRISCV64
 		c.FPReg = framepointerRegRISCV64
 		c.hasGReg = true
+		c.unalignedOK = true
 	case "wasm":
 		c.PtrSize = 8
 		c.RegSize = 8

--- a/src/cmd/compile/internal/ssa/config.go
+++ b/src/cmd/compile/internal/ssa/config.go
@@ -11,6 +11,7 @@ import (
 	"cmd/compile/internal/types"
 	"cmd/internal/obj"
 	"cmd/internal/src"
+	"internal/buildcfg"
 )
 
 // A Config holds readonly compilation information.
@@ -337,7 +338,7 @@ func NewConfig(arch string, types Types, ctxt *obj.Link, optimize, softfloat boo
 		c.floatParamRegs = paramFloatRegRISCV64
 		c.FPReg = framepointerRegRISCV64
 		c.hasGReg = true
-		c.unalignedOK = true
+		c.unalignedOK = buildcfg.GORISCV64EXT.MisalignedFast
 	case "wasm":
 		c.PtrSize = 8
 		c.RegSize = 8

--- a/src/internal/buildcfg/riscv64ext.go
+++ b/src/internal/buildcfg/riscv64ext.go
@@ -13,8 +13,9 @@ import "strings"
 
 // RISC-V 64-bit extension name constants.
 const (
-	Riscv64ExtZacas = "zacas"
-	Riscv64ExtZabha = "zabha"
+	Riscv64ExtZacas       = "zacas"
+	Riscv64ExtZabha       = "zabha"
+	Riscv64MisalignedFast = "misaligned_fast"
 )
 
 // riscv64ExtInfo contains information about a RISC-V 64-bit extension.
@@ -27,12 +28,14 @@ type riscv64ExtInfo struct {
 var riscv64ExtRegistry = []riscv64ExtInfo{
 	{Riscv64ExtZacas, func(g *Goriscv64Extensions) *bool { return &g.Zacas }},
 	{Riscv64ExtZabha, func(g *Goriscv64Extensions) *bool { return &g.Zabha }},
+	{Riscv64MisalignedFast, func(g *Goriscv64Extensions) *bool { return &g.MisalignedFast }},
 }
 
 // Goriscv64Extensions represents the enabled RISC-V 64-bit extensions.
 type Goriscv64Extensions struct {
-	Zacas bool
-	Zabha bool
+	Zacas          bool
+	Zabha          bool
+	MisalignedFast bool
 }
 
 // Has returns true if the given extension is enabled.


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
Zicclsm is an extension that enables support for misaligned loads and stores, and it is mandatory for RVA20U64, RVA22U64, and RVA23U64 (see https://github.com/riscv/riscv-profiles/blob/main/src/profiles.adoc and https://github.com/riscv/riscv-profiles/blob/main/src/rva23-profile.adoc).

This PR enables unaligned memory access optimization for RISC-V 64, allowing memcombine to function properly.

Benchmark results on `encoding/binary`
```
goos: linux
goarch: riscv64
pkg: encoding/binary
cpu: SG2044
                            │ binary_base.riscv64.stats │       binary_opt.riscv64.stats       │
                            │          sec/op           │    sec/op      vs base               │
ReadSlice1000Int32s-30                     35.46µ ± 12%    35.60µ ± 16%        ~ (p=0.937 n=6)
ReadStruct-30                              1.253µ ±  9%    1.300µ ± 20%        ~ (p=0.394 n=6)
WriteStruct-30                             1.030µ ±  8%    1.232µ ± 17%        ~ (p=0.084 n=6)
AppendStruct-30                            99.60n ±  9%    92.76n ±  5%   -6.88% (p=0.026 n=6)
WriteSlice1000Structs-30                   860.3µ ±  8%    828.0µ ±  5%        ~ (p=0.180 n=6)
AppendSlice1000Structs-30                  577.5µ ±  4%    579.7µ ±  6%        ~ (p=0.818 n=6)
ReadSlice1000Structs-30                    1.343m ± 17%    1.106m ± 10%  -17.64% (p=0.002 n=6)
ReadInts-30                                967.1n ±  6%   1050.0n ± 10%   +8.57% (p=0.004 n=6)
WriteInts-30                              1023.5n ± 11%    966.8n ±  8%        ~ (p=0.240 n=6)
AppendInts-30                              261.6n ±  5%    254.0n ± 10%        ~ (p=0.310 n=6)
WriteSlice1000Int32s-30                    18.52µ ±  6%    19.94µ ±  8%   +7.69% (p=0.015 n=6)
AppendSlice1000Int32s-30                   8.619µ ± 15%    8.422µ ±  5%        ~ (p=0.394 n=6)
PutUint16-30                               2.112n ± 18%    2.115n ±  4%        ~ (p=0.855 n=6)
AppendUint16-30                            5.115n ±  5%    5.119n ±  7%        ~ (p=0.818 n=6)
PutUint32-30                               2.785n ±  6%    2.671n ± 12%        ~ (p=0.310 n=6)
AppendUint32-30                            5.253n ±  6%    5.487n ± 23%        ~ (p=0.132 n=6)
PutUint64-30                               8.396n ±  7%    8.049n ±  4%   -4.13% (p=0.026 n=6)
AppendUint64-30                            8.466n ±  9%   10.100n ± 27%  +19.31% (p=0.002 n=6)
LittleEndianPutUint16-30                   2.275n ±  7%    1.693n ±  8%  -25.56% (p=0.002 n=6)
LittleEndianAppendUint16-30                5.195n ±  6%    4.952n ±  3%   -4.67% (p=0.009 n=6)
LittleEndianPutUint32-30                   2.780n ± 11%    1.727n ±  4%  -37.87% (p=0.002 n=6)
LittleEndianAppendUint32-30                5.210n ±  4%    5.093n ± 11%        ~ (p=0.732 n=6)
LittleEndianPutUint64-30                   8.363n ±  4%    1.703n ±  4%  -79.64% (p=0.002 n=6)
LittleEndianAppendUint64-30                8.938n ± 20%    5.151n ±  5%  -42.37% (p=0.002 n=6)
ReadFloats-30                              301.3n ±  8%    307.1n ± 12%        ~ (p=0.589 n=6)
WriteFloats-30                             360.1n ±  9%    300.9n ±  6%  -16.44% (p=0.002 n=6)
ReadSlice1000Float32s-30                   38.62µ ± 17%    35.87µ ± 16%        ~ (p=0.589 n=6)
WriteSlice1000Float32s-30                  37.98µ ±  6%    40.35µ ± 19%        ~ (p=0.093 n=6)
ReadSlice1000Uint8s-30                     3.509µ ± 15%    4.375µ ± 24%  +24.68% (p=0.009 n=6)
WriteSlice1000Uint8s-30                    133.5n ±  5%    139.0n ± 10%        ~ (p=0.240 n=6)
Size/bool-30                               8.654n ±  6%    7.143n ±  6%  -17.46% (p=0.002 n=6)
Size/int8-30                               8.285n ±  7%    6.603n ±  5%  -20.30% (p=0.002 n=6)
Size/int16-30                              9.757n ± 12%    7.603n ± 13%  -22.08% (p=0.002 n=6)
Size/int32-30                             10.000n ±  7%    7.821n ±  5%  -21.79% (p=0.002 n=6)
Size/int64-30                              9.754n ±  3%    8.112n ±  5%  -16.83% (p=0.002 n=6)
Size/uint8-30                              8.394n ±  5%    6.752n ±  5%  -19.57% (p=0.002 n=6)
Size/uint16-30                             9.042n ± 20%    6.848n ±  7%  -24.27% (p=0.002 n=6)
Size/uint32-30                             7.781n ±  5%    6.093n ±  9%  -21.70% (p=0.002 n=6)
Size/uint64-30                             8.857n ±  5%    6.600n ± 11%  -25.48% (p=0.002 n=6)
Size/float32-30                            8.712n ± 11%    6.936n ±  1%  -20.38% (p=0.002 n=6)
Size/float64-30                            8.909n ±  5%    7.452n ±  8%  -16.35% (p=0.002 n=6)
Size/complex64-30                          58.49n ± 11%    56.48n ±  5%        ~ (p=0.180 n=6)
Size/complex128-30                         60.96n ±  3%    57.77n ± 13%        ~ (p=0.065 n=6)
Size/binary.Struct-30                      74.78n ±  6%    73.96n ±  8%        ~ (p=0.853 n=6)
Size/*binary.Struct-30                     85.26n ±  9%    81.59n ±  8%        ~ (p=0.485 n=6)
Size/[]binary.Struct-30                    110.2n ± 24%    105.2n ±  4%        ~ (p=0.074 n=6)
Size/[]binary.Struct#01-30                 107.7n ±  9%    106.8n ± 14%        ~ (p=0.818 n=6)
Size/[1]binary.Struct-30                   106.7n ± 14%    101.7n ±  4%   -4.64% (p=0.013 n=6)
PutUvarint32-30                            29.66n ± 10%    32.31n ±  4%        ~ (p=0.093 n=6)
PutUvarint64-30                            102.7n ±  4%    109.7n ±  5%   +6.82% (p=0.006 n=6)
geomean                                    112.3n          100.7n        -10.28%

                            │ binary_base.riscv64.stats │        binary_opt.riscv64.stats        │
                            │            B/s            │      B/s        vs base                │
ReadSlice1000Int32s-30                    107.6Mi ± 11%    107.2Mi ± 20%         ~ (p=0.937 n=6)
ReadStruct-30                             57.11Mi ±  8%    55.04Mi ± 17%         ~ (p=0.394 n=6)
WriteStruct-30                            69.45Mi ±  7%    58.26Mi ± 20%         ~ (p=0.093 n=6)
AppendStruct-30                           718.5Mi ±  8%    771.1Mi ±  5%    +7.32% (p=0.026 n=6)
WriteSlice1000Structs-30                  83.14Mi ±  7%    86.39Mi ±  5%         ~ (p=0.180 n=6)
AppendSlice1000Structs-30                 123.9Mi ±  4%    123.4Mi ±  6%         ~ (p=0.818 n=6)
ReadSlice1000Structs-30                   53.30Mi ± 14%    64.71Mi ±  9%   +21.41% (p=0.002 n=6)
ReadInts-30                               29.58Mi ±  6%    27.24Mi ±  9%    -7.91% (p=0.004 n=6)
WriteInts-30                              27.95Mi ± 11%    29.59Mi ±  9%         ~ (p=0.240 n=6)
AppendInts-30                             109.4Mi ±  5%    112.7Mi ±  9%         ~ (p=0.310 n=6)
WriteSlice1000Int32s-30                   206.0Mi ±  6%    191.3Mi ±  9%    -7.14% (p=0.015 n=6)
AppendSlice1000Int32s-30                  442.7Mi ± 13%    453.0Mi ±  4%         ~ (p=0.394 n=6)
PutUint16-30                              903.0Mi ± 15%    901.7Mi ±  4%         ~ (p=0.818 n=6)
AppendUint16-30                           372.8Mi ±  5%    372.6Mi ±  7%         ~ (p=0.818 n=6)
PutUint32-30                              1.338Gi ±  5%    1.394Gi ± 11%         ~ (p=0.310 n=6)
AppendUint32-30                           726.2Mi ±  6%    695.4Mi ± 19%         ~ (p=0.132 n=6)
PutUint64-30                              908.7Mi ±  7%    947.9Mi ±  4%    +4.31% (p=0.026 n=6)
AppendUint64-30                           901.2Mi ±  8%    755.1Mi ± 21%   -16.21% (p=0.002 n=6)
LittleEndianPutUint16-30                  838.9Mi ±  8%   1126.5Mi ±  7%   +34.28% (p=0.002 n=6)
LittleEndianAppendUint16-30               367.3Mi ±  6%    385.2Mi ±  3%    +4.86% (p=0.009 n=6)
LittleEndianPutUint32-30                  1.340Gi ± 10%    2.157Gi ±  4%   +60.96% (p=0.002 n=6)
LittleEndianAppendUint32-30               732.5Mi ±  4%    749.1Mi ± 10%         ~ (p=0.818 n=6)
LittleEndianPutUint64-30                  912.4Mi ±  4%   4480.7Mi ±  4%  +391.07% (p=0.002 n=6)
LittleEndianAppendUint64-30               853.6Mi ± 17%   1481.4Mi ±  6%   +73.56% (p=0.002 n=6)
ReadFloats-30                             38.03Mi ±  9%    37.27Mi ± 11%         ~ (p=0.589 n=6)
WriteFloats-30                            31.79Mi ± 10%    38.04Mi ±  6%   +19.65% (p=0.002 n=6)
ReadSlice1000Float32s-30                  98.79Mi ± 18%   106.36Mi ± 14%         ~ (p=0.589 n=6)
WriteSlice1000Float32s-30                100.50Mi ±  6%    94.54Mi ± 16%         ~ (p=0.093 n=6)
ReadSlice1000Uint8s-30                    271.8Mi ± 13%    218.0Mi ± 20%   -19.80% (p=0.009 n=6)
WriteSlice1000Uint8s-30                   6.976Gi ±  5%    6.701Gi ± 11%         ~ (p=0.240 n=6)
PutUvarint32-30                           128.7Mi ±  9%    118.1Mi ±  4%         ~ (p=0.093 n=6)
PutUvarint64-30                           74.31Mi ±  4%    69.60Mi ±  5%    -6.33% (p=0.009 n=6)
geomean                                   242.5Mi          263.4Mi          +8.60%

```

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required