### PR TITLE
Fix: p256 compile error with purego tag

### DIFF
--- a/src/crypto/internal/fips140/nistec/fiat/p256_impl.go
+++ b/src/crypto/internal/fips140/nistec/fiat/p256_impl.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !riscv64
+//go:build !riscv64 || purego
 
 package fiat
 

--- a/src/crypto/internal/fips140/nistec/fiat/p256_impl_riscv64.go
+++ b/src/crypto/internal/fips140/nistec/fiat/p256_impl_riscv64.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !purego
+//go:build riscv64 && !purego
 
 package fiat
 


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
```
##### crypto with tag purego (build and vet only)
# crypto/internal/fips140/nistec/fiat
crypto/internal/fips140/nistec/fiat/p256.go:108:2: undefined: p256Mul
?       crypto/internal/boring/bbig     [no test files]
?       crypto/internal/boring/sig      [no test files]
?       crypto/internal/constanttime    [no test files]
?       crypto/internal/cryptotest      [no test files]
?       crypto/internal/entropy [no test files]
?       crypto/internal/fips140 [no test files]
?       crypto/internal/fips140/alias   [no test files]
?       crypto/internal/fips140/check   [no test files]
?       crypto/internal/fips140/check/checktest [no test files]
?       crypto/internal/fips140/ed25519 [no test files]
?       crypto/internal/fips140/hkdf    [no test files]
?       crypto/internal/fips140/hmac    [no test files]
?       crypto/internal/fips140/pbkdf2  [no test files]
?       crypto/internal/fips140/sha256  [no test files]
?       crypto/internal/fips140/sha3    [no test files]
?       crypto/internal/fips140/sha512  [no test files]
?       crypto/internal/fips140/ssh     [no test files]
?       crypto/internal/fips140/tls12   [no test files]
?       crypto/internal/fips140/tls13   [no test files]
?       crypto/internal/fips140deps/byteorder   [no test files]
?       crypto/internal/fips140deps/cpu [no test files]
?       crypto/internal/fips140deps/godebug     [no test files]
?       crypto/internal/fips140hash     [no test files]
?       crypto/internal/fips140only     [no test files]
?       crypto/internal/impl    [no test files]
?       crypto/internal/randutil        [no test files]
?       crypto/internal/sysrand/internal/seccomp        [no test files]
?       crypto/tls/internal/fips140tls  [no test files]
?       crypto/x509/pkix        [no test files]
2026/01/27 15:43:07 Failed: exit status 1
```

On riscv64 platform, compile with tag `purego` will report error due to lack of `purego` compile tag in `p256_impl.go`.

This PR fix the bug and now all tests can pass.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required