### PR TITLE
cmd/internal/sys: enable CanMergeLoads for riscv64 when misaligned access is fast

### DIFF
--- a/src/cmd/internal/sys/arch.go
+++ b/src/cmd/internal/sys/arch.go
@@ -6,6 +6,7 @@ package sys
 
 import (
 	"encoding/binary"
+	"internal/buildcfg"
 	"internal/goarch"
 )
 
@@ -237,7 +238,7 @@ var ArchRISCV64 = &Arch{
 	RegSize:        8,
 	MinLC:          2,
 	Alignment:      8, // riscv unaligned loads work, but are really slow (trap + simulated by OS)
-	CanMergeLoads:  false,
+	CanMergeLoads:  buildcfg.GORISCV64EXT.MisalignedFast,
 	HasLR:          true,
 	FixedFrameSize: 8, // LR
 }


### PR DESCRIPTION
Previously, CanMergeLoads was hardcoded to false for riscv64. This 
prevented the inliner from recognizing that encoding/binary and 
internal/byteorder functions could be lowered to a single instruction 
on modern RISC-V hardware.

This change ties CanMergeLoads to buildcfg.GORISCV64EXT.MisalignedFast, 
aligning it with the unalignedOK state. When fast misaligned access is 
available (e.g., via "GORISCV64=rva23u64,misaligned_fast"):

1. The inliner now treats Uint64/Uint32 operations as "cheap", 
   promoting inlining of byte-order sensitive code.
2. The SSA backend continues to merge contiguous memory accesses 
   into single wide instructions.

This synergistic optimization reduces function call overhead and 
leverages hardware capabilities to improve performance on high-end 
RISC-V cores while maintaining safe, conservative behavior on 
baseline hardware.

Benchmark results show significant performance improvement in the benchmark suite.
For example, in the LZ benchmark from github.com/flanglet/kanzi-go/benchmark:

goos: linux
goarch: riscv64
cpu: SG2044
pkg: github.com/flanglet/kanzi-go/benchmark
   │ kanzi_rv_LZ_nomergeload-0204.txt │      kanzi_rv_LZ_mergeload-0204.txt      │
   │              sec/op              │   sec/op     vs base                │
LZ                        3.957m ± 1%   2.868m ± 8%  -27.54% (p=0.000 n=10)

Updates #105 
