### PR TITLE
fix: fix arg type of cmo instrucions in disassembler

### DIFF
--- a/src/cmd/asm/internal/asm/testdata/riscv64.s
+++ b/src/cmd/asm/internal/asm/testdata/riscv64.s
@@ -302,12 +302,12 @@ start:
 	AMOCASH		X5, (X6), X7			// af13532e
 
 	// 19.6.1: Cache-Block Management Instructions (Zicbom)
-	CBOCLEAN	X5				// 0fa01200
-	CBOFLUSH	X5				// 0fa02200
-	CBOINVAL	X5				// 0fa00200
+	CBOCLEAN	(X5)					// 0fa01200
+	CBOFLUSH	(X5)					// 0fa02200
+	CBOINVAL	(X5)					// 0fa00200
 
 	// 19.6.2: Cache-Block Zero Instructions (Zicboz)
-	CBOZERO		X5				// 0fa04200
+	CBOZERO		(X5)					// 0fa04200
 
 	// 19.6.3: Cache-Block Prefetch Instructions
 	PREFETCHI 448(X5)					// 13e0021c

--- a/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
+++ b/src/cmd/vendor/golang.org/x/arch/riscv64/riscv64asm/tables.go
@@ -2578,13 +2578,13 @@ var instFormats = [...]instFormat{
 	// BSETI rd, rs1, shamt6
 	{mask: 0xfc00707f, value: 0x28001013, op: BSETI, args: argTypeList{arg_rd, arg_rs1, arg_shamt6}},
 	// CBO.CLEAN rs1
-	{mask: 0xfff07fff, value: 0x0010200f, op: CBO_CLEAN, args: argTypeList{arg_rs1}},
+	{mask: 0xfff07fff, value: 0x0010200f, op: CBO_CLEAN, args: argTypeList{arg_rs1_ptr}},
 	// CBO.FLUSH rs1
-	{mask: 0xfff07fff, value: 0x0020200f, op: CBO_FLUSH, args: argTypeList{arg_rs1}},
+	{mask: 0xfff07fff, value: 0x0020200f, op: CBO_FLUSH, args: argTypeList{arg_rs1_ptr}},
 	// CBO.INVAL rs1
-	{mask: 0xfff07fff, value: 0x0000200f, op: CBO_INVAL, args: argTypeList{arg_rs1}},
+	{mask: 0xfff07fff, value: 0x0000200f, op: CBO_INVAL, args: argTypeList{arg_rs1_ptr}},
 	// CBO.ZERO rs1
-	{mask: 0xfff07fff, value: 0x0040200f, op: CBO_ZERO, args: argTypeList{arg_rs1}},
+	{mask: 0xfff07fff, value: 0x0040200f, op: CBO_ZERO, args: argTypeList{arg_rs1_ptr}},
 	// CLMUL rd, rs1, rs2
 	{mask: 0xfe00707f, value: 0x0a001033, op: CLMUL, args: argTypeList{arg_rd, arg_rs1, arg_rs2}},
 	// CLMULH rd, rs1, rs2


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required