### PR TITLE
cmd/compile/internal/ssa: enable memory combine when bits swap needed on riscv64

### DIFF
--- a/src/cmd/compile/internal/ssa/config.go
+++ b/src/cmd/compile/internal/ssa/config.go
@@ -339,9 +339,9 @@ func NewConfig(arch string, types Types, ctxt *obj.Link, optimize, softfloat boo
 		c.FPReg = framepointerRegRISCV64
 		c.hasGReg = true
 		c.unalignedOK = buildcfg.GORISCV64EXT.MisalignedFast
-		c.haveBswap64 = true
-		c.haveBswap32 = true
-		c.haveBswap16 = true
+		c.haveBswap64 = buildcfg.GORISCV64 >= 22
+		c.haveBswap32 = buildcfg.GORISCV64 >= 22
+		c.haveBswap16 = buildcfg.GORISCV64 >= 22
 	case "wasm":
 		c.PtrSize = 8
 		c.RegSize = 8

--- a/src/cmd/compile/internal/ssa/config.go
+++ b/src/cmd/compile/internal/ssa/config.go
@@ -339,6 +339,9 @@ func NewConfig(arch string, types Types, ctxt *obj.Link, optimize, softfloat boo
 		c.FPReg = framepointerRegRISCV64
 		c.hasGReg = true
 		c.unalignedOK = buildcfg.GORISCV64EXT.MisalignedFast
+		c.haveBswap64 = true
+		c.haveBswap32 = true
+		c.haveBswap16 = true
 	case "wasm":
 		c.PtrSize = 8
 		c.RegSize = 8


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions

We have already enabled memory combine in #105.

When byte swapping is required (e.g., reading from or writing to big-endian data on a little-endian machine), the memory combine optimizer checks whether `haveBswap64`, `haveBswap32`, or `haveBswap16` are set.

The RISC-V port already supports `Bswap64/32/16`, as shown below:
```
	case OpBswap16:
		return rewriteValueRISCV64_OpBswap16(v)
	case OpBswap32:
		return rewriteValueRISCV64_OpBswap32(v)
	case OpBswap64:
		v.Op = OpRISCV64REV8
		return true
```

However, `haveBswapXX` was not set in config.go for the RISC-V port. I believe this is because unaligned memory access was not enabled previously (note that `haveBswapXX` only takes effect when `unalignedOk` is set).

Performance data:
```
goos: linux
goarch: riscv64
pkg: encoding/binary
cpu: SG2044
                │ base-2.data │             opt-2.data              │
                │   sec/op    │    sec/op     vs base               │
PutUint16-30      2.065n ± 1%   1.797n ± 19%        ~ (p=0.058 n=6)
PutUint32-30      2.623n ± 4%   1.787n ±  3%  -31.84% (p=0.002 n=6)
PutUint64-30      8.017n ± 3%   1.738n ±  3%  -78.32% (p=0.002 n=6)
AppendUint16-30   5.005n ± 5%   4.915n ±  3%        ~ (p=0.180 n=6)
AppendUint32-30   5.113n ± 5%   5.004n ±  6%        ~ (p=0.132 n=6)
AppendUint64-30   8.309n ± 6%   4.896n ±  2%  -41.08% (p=0.002 n=6)
geomean           4.580n        2.960n        -35.38%

                │ base-2.data  │               opt-2.data               │
                │     B/s      │      B/s        vs base                │
PutUint16-30      923.6Mi ± 1%   1061.4Mi ± 16%         ~ (p=0.065 n=6)
PutUint32-30      1.421Gi ± 4%    2.084Gi ±  3%   +46.69% (p=0.002 n=6)
PutUint64-30      951.6Mi ± 3%   4388.6Mi ±  3%  +361.16% (p=0.002 n=6)
AppendUint16-30   381.1Mi ± 5%    388.0Mi ±  4%         ~ (p=0.180 n=6)
AppendUint32-30   746.1Mi ± 4%    762.3Mi ±  6%         ~ (p=0.132 n=6)
AppendUint64-30   918.2Mi ± 5%   1558.5Mi ±  2%   +69.73% (p=0.002 n=6)
geomean           832.9Mi         1.259Gi         +54.74%

```

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required