### PR TITLE
runtime: optimize memmove for vector small and medium copies

### DIFF
--- a/src/runtime/memmove_riscv64.s
+++ b/src/runtime/memmove_riscv64.s
@@ -45,50 +45,45 @@ TEXT runtime·memmove<ABIInternal>(SB),NOSPLIT|NOFRAME,$0-24
 	PCALIGN	$16
 #ifdef EnableSmallSizeMemVector
 f_vector_dispatch:
-	MOV	$128, X6
+	MOV		$16, X6
+#ifdef VLen_256
+	SLLI	$1, X6
+#endif
+#ifdef VLen_512
+	SLLI	$2, X6
+#endif
+	BGEU	X6, X12, f_vector_single
+	SLLI	$2, X6
 	BGTU	X12, X6, f_vector_loop
-	MOV	$64, X6
+	SRLI	$1, X6
 	BGTU	X12, X6, f_vector_quarter
-	MOV	$32, X6
-	BGTU	X12, X6, f_vector_double
 
-// Copy 1..32 bytes
-	PCALIGN	$16
-f_vector_single:
-	VSETVLI	X12, E8, M1, TA, MA, X5
-	VLE8V	(X11), V8
-	VSE8V	V8, (X10)
-	ADD	X5, X10
-	ADD	X5, X11
-	SUB	X5, X12
-	BNEZ	X12, f_vector_single
-	RET
-
-// Copy 33..64 bytes
+// Copy (vlen+1)..(2*vlen) bytes
 	PCALIGN	$16
 f_vector_double:
 	VSETVLI	X12, E8, M2, TA, MA, X5
 	VLE8V	(X11), V8
 	VSE8V	V8, (X10)
-	ADD	X5, X10
-	ADD	X5, X11
-	SUB	X5, X12
-	BNEZ	X12, f_vector_double
 	RET
 
-// Copy 65..128 bytes
+// Copy 1..(vlen) bytes
+	PCALIGN	$16
+f_vector_single:
+	VSETVLI	X12, E8, M1, TA, MA, X5
+	VLE8V	(X11), V8
+	VSE8V	V8, (X10)
+	RET
+
+// Copy (2*vlen+1)..(4*vlen) bytes
 	PCALIGN	$16
 f_vector_quarter:
 	VSETVLI	X12, E8, M4, TA, MA, X5
 	VLE8V	(X11), V8
 	VSE8V	V8, (X10)
-	ADD	X5, X10
-	ADD	X5, X11
-	SUB	X5, X12
-	BNEZ	X12, f_vector_quarter
 	RET
 #endif
 
+// Copy (4*vlen+1).. bytes
 	PCALIGN	$16
 f_vector_loop:
 	VSETVLI	X12, E8, M8, TA, MA, X5
@@ -279,26 +274,20 @@ backward:
 	PCALIGN	$16
 #ifdef EnableSmallSizeMemVector
 b_vector_dispatch:
-	MOV	$128, X6
+	MOV		$16, X6
+#ifdef VLen_256
+	SLLI	$1, X6
+#endif
+#ifdef VLen_512
+	SLLI	$2, X6
+#endif
+	BGEU	X6, X12, b_vector_single
+	SLLI	$2, X6
 	BGTU	X12, X6, b_vector_loop
-	MOV	$64, X6
+	SRLI	$1, X6
 	BGTU	X12, X6, b_vector_quarter
-	MOV	$32, X6
-	BGTU	X12, X6, b_vector_double
 
-// Copy 1..32 bytes
-	PCALIGN	$16
-b_vector_single:
-	VSETVLI	X12, E8, M1, TA, MA, X5
-	SUB	X5, X10
-	SUB	X5, X11
-	VLE8V	(X11), V8
-	VSE8V	V8, (X10)
-	SUB	X5, X12
-	BNEZ	X12, b_vector_single
-	RET
-
-// Copy 33..64 bytes
+// Copy (vlen+1)..(2*vlen) bytes
 	PCALIGN	$16
 b_vector_double:
 	VSETVLI	X12, E8, M2, TA, MA, X5
@@ -306,11 +295,19 @@ b_vector_double:
 	SUB	X5, X11
 	VLE8V	(X11), V8
 	VSE8V	V8, (X10)
-	SUB	X5, X12
-	BNEZ	X12, b_vector_double
 	RET
 
-// Copy 65..128 bytes
+// Copy 1..(vlen) bytes
+	PCALIGN	$16
+b_vector_single:
+	VSETVLI	X12, E8, M1, TA, MA, X5
+	SUB	X5, X10
+	SUB	X5, X11
+	VLE8V	(X11), V8
+	VSE8V	V8, (X10)
+	RET
+
+// Copy (2*vlen+1)..(4*vlen) bytes
 	PCALIGN	$16
 b_vector_quarter:
 	VSETVLI	X12, E8, M4, TA, MA, X5
@@ -318,11 +315,10 @@ b_vector_quarter:
 	SUB	X5, X11
 	VLE8V	(X11), V8
 	VSE8V	V8, (X10)
-	SUB	X5, X12
-	BNEZ	X12, b_vector_quarter
 	RET
 #endif
 
+// Copy (4*vlen+1).. bytes
 	PCALIGN	$16
 b_vector_loop:
 	VSETVLI	X12, E8, M8, TA, MA, X5

--- a/src/runtime/memmove_riscv64.s
+++ b/src/runtime/memmove_riscv64.s
@@ -20,67 +20,75 @@ TEXT runtime·memmove<ABIInternal>(SB),NOSPLIT|NOFRAME,$0-24
 	// buffer and go backward.
 	BGTU	X10, X11, backward
 
+#ifndef EnableSmallSizeMemVector
 	// If less than 8 bytes, do single byte copies.
 	MOV	$8, X9
 	BLT	X12, X9, f_loop4_check
+#endif
 
 #ifndef hasV
 	MOVB	internal∕cpu·RISCV64+const_offsetRISCV64HasV(SB), X5
 	BEQZ	X5, f_memmove_scalar
 #endif
 
+#ifndef EnableSmallSizeMemVector
+	// Use vector if destination and source are not 8 byte aligned.
+	OR	X10, X11, X5
+	AND	$7, X5
+	BNEZ	X5, f_vector_loop
+
+	// Use scalar if destination and source are 8 byte aligned and n <= 64 bytes.
+	SUB	$64, X12, X6
+	BLEZ	X6, f_loop_check
+#endif
+
 	PCALIGN	$16
+#ifdef EnableSmallSizeMemVector
 f_vector_dispatch:
 	MOV	$128, X6
 	BGTU	X12, X6, f_vector_loop
+	MOV	$64, X6
+	BGTU	X12, X6, f_vector_quarter
 	MOV	$32, X6
-	BGTU	X12, X6, f_vector_medium
+	BGTU	X12, X6, f_vector_double
 
-// Small copies: 1..32 bytes
-f_vector_small:
+// Copy 1..32 bytes
+	PCALIGN	$16
+f_vector_single:
 	VSETVLI	X12, E8, M1, TA, MA, X5
 	VLE8V	(X11), V8
-	ADD	X11, X12, X6
-	SUB	X5, X6
-	VLE8V	(X6), V9
-	ADD	X10, X12, X7
-	SUB	X5, X7
-	VSE8V	V9, (X7)
 	VSE8V	V8, (X10)
+	ADD	X5, X10
+	ADD	X5, X11
+	SUB	X5, X12
+	BNEZ	X12, f_vector_single
 	RET
 
-// Medium copies: 33..128 bytes
-f_vector_medium:
-	ADD	X11, X12, X6
-	ADD	X10, X12, X7
+// Copy 33..64 bytes
+	PCALIGN	$16
+f_vector_double:
 	VSETVLI	X12, E8, M2, TA, MA, X5
 	VLE8V	(X11), V8
-	SUB	$32, X6, X8
-	VLE8V	(X8), V10
-	MOV	$64, X9
-	BGTU	X12, X9, f_vector_medium_65_128
 	VSE8V	V8, (X10)
-	SUB	$32, X7, X8
-	VSE8V	V10, (X8)
-	RET
-f_vector_medium_65_128:
-	ADD	$32, X11, X8
-	VLE8V	(X8), V12
-	MOV	$96, X9
-	BLEU	X12, X9, f_vector_medium_96
-	SUB	$64, X6, X8
-	VLE8V	(X8), V14
-	SUB	$64, X7, X9
-	VSE8V	V14, (X9)
-f_vector_medium_96:
-	VSE8V	V8, (X10)
-	ADD	$32, X10, X8
-	VSE8V	V12, (X8)
-	SUB	$32, X7, X9
-	VSE8V	V10, (X9)
+	ADD	X5, X10
+	ADD	X5, X11
+	SUB	X5, X12
+	BNEZ	X12, f_vector_double
 	RET
 
-// Copy more than 128 bytes.
+// Copy 65..128 bytes
+	PCALIGN	$16
+f_vector_quarter:
+	VSETVLI	X12, E8, M4, TA, MA, X5
+	VLE8V	(X11), V8
+	VSE8V	V8, (X10)
+	ADD	X5, X10
+	ADD	X5, X11
+	SUB	X5, X12
+	BNEZ	X12, f_vector_quarter
+	RET
+#endif
+
 	PCALIGN	$16
 f_vector_loop:
 	VSETVLI	X12, E8, M8, TA, MA, X5
@@ -92,6 +100,7 @@ f_vector_loop:
 	BNEZ	X12, f_vector_loop
 	RET
 
+#ifndef hasV
 f_memmove_scalar:
 	// Check alignment - if alignment differs we have to do one byte at a time.
 	AND	$7, X10, X5
@@ -109,7 +118,9 @@ f_align:
 	ADD	$1, X10
 	ADD	$1, X11
 	BNEZ	X5, f_align
+#endif
 
+#ifndef EnableSmallSizeMemVector
 f_loop_check:
 	MOV	$16, X9
 	BLT	X12, X9, f_loop8_check
@@ -237,75 +248,81 @@ f_loop1:
 	ADD	$1, X11
 	SUB	$1, X12
 	JMP	f_loop1
+#endif
 
 backward:
 	ADD	X10, X12, X10
 	ADD	X11, X12, X11
 
+#ifndef EnableSmallSizeMemVector
 	// If less than 8 bytes, do single byte copies.
 	MOV	$8, X9
 	BLT	X12, X9, b_loop4_check
+#endif
 
 #ifndef hasV
 	MOVB	internal∕cpu·RISCV64+const_offsetRISCV64HasV(SB), X5
 	BEQZ	X5, b_memmove_scalar
 #endif
 
-	// 有向量时统一走向量路径，按 n 分小块/中块/循环（与 forward 一致）
-	// 向量路径分发：按长度走小块(1-32)、中块(33-128)或循环(129+)，与 gcc_plan9 一致
+#ifndef EnableSmallSizeMemVector
+	// Use vector if destination and source are not 8 byte aligned.
+	OR	X10, X11, X5
+	AND	$7, X5
+	BNEZ	X5, b_vector_loop
+
+	// Use scalar if destination and source are 8 byte aligned and n <= 64 bytes.
+	SUB	$32, X12, X6
+	BLEZ	X6, b_loop_check
+#endif
+
 	PCALIGN	$16
+#ifdef EnableSmallSizeMemVector
 b_vector_dispatch:
 	MOV	$128, X6
 	BGTU	X12, X6, b_vector_loop
+	MOV	$64, X6
+	BGTU	X12, X6, b_vector_quarter
 	MOV	$32, X6
-	BGTU	X12, X6, b_vector_medium
+	BGTU	X12, X6, b_vector_double
 
-// Small copies: 1..32 bytes
-b_vector_small:
+// Copy 1..32 bytes
+	PCALIGN	$16
+b_vector_single:
 	VSETVLI	X12, E8, M1, TA, MA, X5
-	SUB	X5, X11, X6
-	VLE8V	(X6), V8
-	SUB	X12, X11, X7
-	VLE8V	(X7), V9
-	SUB	X5, X10, X6
-	VSE8V	V8, (X6)
-	SUB	X12, X10, X7
-	VSE8V	V9, (X7)
+	SUB	X5, X10
+	SUB	X5, X11
+	VLE8V	(X11), V8
+	VSE8V	V8, (X10)
+	SUB	X5, X12
+	BNEZ	X12, b_vector_single
 	RET
 
-// Medium copies: 33..128 bytes
-b_vector_medium:
+// Copy 33..64 bytes
+	PCALIGN	$16
+b_vector_double:
 	VSETVLI	X12, E8, M2, TA, MA, X5
-	SUB	$32, X11, X6
-	VLE8V	(X6), V8
-	SUB	X12, X11, X8
-	VLE8V	(X8), V10
-	MOV	$64, X9
-	BGTU	X12, X9, b_vector_medium_65_128
-	SUB	$32, X10, X7
-	VSE8V	V8, (X7)
-	SUB	X12, X10, X9
-	VSE8V	V10, (X9)
-	RET
-b_vector_medium_65_128:
-	SUB	$64, X11, X8
-	VLE8V	(X8), V12
-	MOV	$96, X9
-	BLEU	X12, X9, b_vector_medium_96
-	SUB	$96, X11, X8
-	VLE8V	(X8), V14
-	SUB	$96, X10, X9
-	VSE8V	V14, (X9)
-b_vector_medium_96:
-	SUB	$32, X10, X7
-	VSE8V	V8, (X7)
-	SUB	$64, X10, X8
-	VSE8V	V12, (X8)
-	SUB	X12, X10, X9
-	VSE8V	V10, (X9)
+	SUB	X5, X10
+	SUB	X5, X11
+	VLE8V	(X11), V8
+	VSE8V	V8, (X10)
+	SUB	X5, X12
+	BNEZ	X12, b_vector_double
 	RET
 
-// Copy more than 128 bytes.
+// Copy 65..128 bytes
+	PCALIGN	$16
+b_vector_quarter:
+	VSETVLI	X12, E8, M4, TA, MA, X5
+	SUB	X5, X10
+	SUB	X5, X11
+	VLE8V	(X11), V8
+	VSE8V	V8, (X10)
+	SUB	X5, X12
+	BNEZ	X12, b_vector_quarter
+	RET
+#endif
+
 	PCALIGN	$16
 b_vector_loop:
 	VSETVLI	X12, E8, M8, TA, MA, X5
@@ -317,6 +334,7 @@ b_vector_loop:
 	BNEZ	X12, b_vector_loop
 	RET
 
+#ifndef hasV
 b_memmove_scalar:
 	// Check alignment - if alignment differs we have to do one byte at a time.
 	AND	$7, X10, X5
@@ -333,7 +351,9 @@ b_align:
 	MOVB	0(X11), X14
 	MOVB	X14, 0(X10)
 	BNEZ	X5, b_align
+#endif
 
+#ifndef EnableSmallSizeMemVector
 b_loop_check:
 	MOV	$16, X9
 	BLT	X12, X9, b_loop8_check
@@ -459,6 +479,7 @@ b_loop1:
 	MOVB	X14, 0(X10)
 	SUB	$1, X12
 	JMP	b_loop1
+#endif
 
 done:
 	RET

--- a/src/runtime/memmove_riscv64.s
+++ b/src/runtime/memmove_riscv64.s
@@ -42,8 +42,8 @@ TEXT runtime·memmove<ABIInternal>(SB),NOSPLIT|NOFRAME,$0-24
 	BLEZ	X6, f_loop_check
 #endif
 
-	PCALIGN	$16
 #ifdef EnableSmallSizeMemVector
+	PCALIGN	$16
 f_vector_dispatch:
 	MOV		$16, X6
 #ifdef VLen_256
@@ -271,8 +271,8 @@ backward:
 	BLEZ	X6, b_loop_check
 #endif
 
-	PCALIGN	$16
 #ifdef EnableSmallSizeMemVector
+	PCALIGN	$16
 b_vector_dispatch:
 	MOV		$16, X6
 #ifdef VLen_256

--- a/src/runtime/memmove_riscv64.s
+++ b/src/runtime/memmove_riscv64.s
@@ -29,15 +29,58 @@ TEXT runtime·memmove<ABIInternal>(SB),NOSPLIT|NOFRAME,$0-24
 	BEQZ	X5, f_memmove_scalar
 #endif
 
-	// Use vector if destination and source are not 8 byte aligned.
-	OR	X10, X11, X5
-	AND	$7, X5
-	BNEZ	X5, f_vector_loop
+	PCALIGN	$16
+f_vector_dispatch:
+	MOV	$128, X6
+	BGTU	X12, X6, f_vector_loop
+	MOV	$32, X6
+	BGTU	X12, X6, f_vector_medium
 
-	// Use scalar if destination and source are 8 byte aligned and n <= 64 bytes.
-	SUB	$64, X12, X6
-	BLEZ	X6, f_loop_check
+// Small copies: 1..32 bytes
+f_vector_small:
+	VSETVLI	X12, E8, M1, TA, MA, X5
+	VLE8V	(X11), V8
+	ADD	X11, X12, X6
+	SUB	X5, X6
+	VLE8V	(X6), V9
+	ADD	X10, X12, X7
+	SUB	X5, X7
+	VSE8V	V9, (X7)
+	VSE8V	V8, (X10)
+	RET
 
+// Medium copies: 33..128 bytes
+f_vector_medium:
+	ADD	X11, X12, X6
+	ADD	X10, X12, X7
+	VSETVLI	X12, E8, M2, TA, MA, X5
+	VLE8V	(X11), V8
+	SUB	$32, X6, X8
+	VLE8V	(X8), V10
+	MOV	$64, X9
+	BGTU	X12, X9, f_vector_medium_65_128
+	VSE8V	V8, (X10)
+	SUB	$32, X7, X8
+	VSE8V	V10, (X8)
+	RET
+f_vector_medium_65_128:
+	ADD	$32, X11, X8
+	VLE8V	(X8), V12
+	MOV	$96, X9
+	BLEU	X12, X9, f_vector_medium_96
+	SUB	$64, X6, X8
+	VLE8V	(X8), V14
+	SUB	$64, X7, X9
+	VSE8V	V14, (X9)
+f_vector_medium_96:
+	VSE8V	V8, (X10)
+	ADD	$32, X10, X8
+	VSE8V	V12, (X8)
+	SUB	$32, X7, X9
+	VSE8V	V10, (X9)
+	RET
+
+// Copy more than 128 bytes.
 	PCALIGN	$16
 f_vector_loop:
 	VSETVLI	X12, E8, M8, TA, MA, X5
@@ -208,15 +251,61 @@ backward:
 	BEQZ	X5, b_memmove_scalar
 #endif
 
-	// Use vector if destination and source are not 8 byte aligned.
-	OR	X10, X11, X5
-	AND	$7, X5
-	BNEZ	X5, b_vector_loop
+	// 有向量时统一走向量路径，按 n 分小块/中块/循环（与 forward 一致）
+	// 向量路径分发：按长度走小块(1-32)、中块(33-128)或循环(129+)，与 gcc_plan9 一致
+	PCALIGN	$16
+b_vector_dispatch:
+	MOV	$128, X6
+	BGTU	X12, X6, b_vector_loop
+	MOV	$32, X6
+	BGTU	X12, X6, b_vector_medium
 
-	// Use scalar if destination and source are 8 byte aligned and n <= 64 bytes.
-	SUB	$32, X12, X6
-	BLEZ	X6, b_loop_check
+// Small copies: 1..32 bytes
+b_vector_small:
+	VSETVLI	X12, E8, M1, TA, MA, X5
+	SUB	X5, X11, X6
+	VLE8V	(X6), V8
+	SUB	X12, X11, X7
+	VLE8V	(X7), V9
+	SUB	X5, X10, X6
+	VSE8V	V8, (X6)
+	SUB	X12, X10, X7
+	VSE8V	V9, (X7)
+	RET
 
+// Medium copies: 33..128 bytes
+b_vector_medium:
+	VSETVLI	X12, E8, M2, TA, MA, X5
+	SUB	$32, X11, X6
+	VLE8V	(X6), V8
+	SUB	X12, X11, X8
+	VLE8V	(X8), V10
+	MOV	$64, X9
+	BGTU	X12, X9, b_vector_medium_65_128
+	SUB	$32, X10, X7
+	VSE8V	V8, (X7)
+	SUB	X12, X10, X9
+	VSE8V	V10, (X9)
+	RET
+b_vector_medium_65_128:
+	SUB	$64, X11, X8
+	VLE8V	(X8), V12
+	MOV	$96, X9
+	BLEU	X12, X9, b_vector_medium_96
+	SUB	$96, X11, X8
+	VLE8V	(X8), V14
+	SUB	$96, X10, X9
+	VSE8V	V14, (X9)
+b_vector_medium_96:
+	SUB	$32, X10, X7
+	VSE8V	V8, (X7)
+	SUB	$64, X10, X8
+	VSE8V	V12, (X8)
+	SUB	X12, X10, X9
+	VSE8V	V10, (X9)
+	RET
+
+// Copy more than 128 bytes.
 	PCALIGN	$16
 b_vector_loop:
 	VSETVLI	X12, E8, M8, TA, MA, X5


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
Optimize memmove for vector small and medium copies.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Performance data
Tested on SG2044, taskset to an idle core:
```
goos: linux
goarch: riscv64
pkg: runtime
                                 │  old_sg.txt   │              new_sg.txt              │
                                 │    sec/op     │    sec/op      vs base               │
Memmove/0                           5.445n ±  0%    5.455n ±  1%        ~ (p=0.288 n=6)
Memmove/1                           10.40n ±  0%    10.40n ±  0%        ~ (p=1.000 n=6)
Memmove/2                           11.95n ±  0%    11.94n ±  0%        ~ (p=0.210 n=6)
Memmove/3                           13.49n ±  0%    13.49n ±  0%        ~ (p=1.000 n=6)
Memmove/4                           8.976n ±  1%    9.022n ±  1%        ~ (p=0.394 n=6)
Memmove/5                           10.74n ±  0%    10.74n ±  0%        ~ (p=0.545 n=6)
Memmove/6                           12.27n ±  0%    12.28n ±  1%        ~ (p=0.617 n=6)
Memmove/7                           13.79n ±  0%    13.82n ±  0%        ~ (p=0.216 n=6)
Memmove/8                           9.535n ±  1%    8.808n ±  1%   -7.61% (p=0.002 n=6)
Memmove/9                           8.059n ±  1%    8.800n ±  1%   +9.19% (p=0.002 n=6)
Memmove/10                          8.010n ±  1%    8.793n ±  1%   +9.77% (p=0.002 n=6)
Memmove/11                          8.038n ±  1%    8.799n ±  1%   +9.46% (p=0.002 n=6)
Memmove/12                          8.041n ±  0%    8.796n ±  1%   +9.38% (p=0.002 n=6)
Memmove/13                          8.044n ±  1%    8.820n ±  0%   +9.64% (p=0.002 n=6)
Memmove/14                          8.070n ±  0%    8.799n ±  0%   +9.03% (p=0.002 n=6)
Memmove/15                          8.048n ±  1%    8.784n ±  0%   +9.14% (p=0.002 n=6)
Memmove/16                         10.105n ±  0%    8.824n ±  1%  -12.68% (p=0.002 n=6)
Memmove/32                         11.405n ±  0%    8.820n ±  0%  -22.66% (p=0.002 n=6)
Memmove/64                         11.355n ±  0%    9.196n ±  0%  -19.01% (p=0.002 n=6)
Memmove/128                         8.487n ±  0%   10.655n ±  1%  +25.54% (p=0.002 n=6)
Memmove/256                         15.66n ± 80%    15.27n ±  0%   -2.46% (p=0.002 n=6)
Memmove/512                         67.51n ±  6%    28.55n ±  1%  -57.70% (p=0.002 n=6)
Memmove/1024                       365.20n ±  3%    57.90n ± 11%  -84.15% (p=0.002 n=6)
Memmove/2048                        799.7n ±  6%    133.3n ± 10%  -83.32% (p=0.002 n=6)
Memmove/4096                       2313.5n ±  5%    358.8n ± 20%  -84.49% (p=0.002 n=6)
MemmoveOverlap/32                  25.060n ±  1%    9.614n ±  1%  -61.64% (p=0.002 n=6)
MemmoveOverlap/64                   19.23n ±  1%    10.23n ±  1%  -46.80% (p=0.002 n=6)
MemmoveOverlap/128                  11.55n ±  1%    12.11n ±  1%   +4.85% (p=0.002 n=6)
MemmoveOverlap/256                  16.23n ±  0%    16.24n ±  0%        ~ (p=0.665 n=6)
MemmoveOverlap/512                  29.15n ±  0%    28.79n ±  0%   -1.25% (p=0.002 n=6)
MemmoveOverlap/1024                 55.89n ±  0%    55.59n ±  0%   -0.53% (p=0.002 n=6)
MemmoveOverlap/2048                 106.5n ±  0%    106.9n ±  0%   +0.38% (p=0.002 n=6)
MemmoveOverlap/4096                 218.4n ±  0%    221.0n ±  0%   +1.19% (p=0.002 n=6)
MemmoveUnalignedDst/0               5.446n ±  0%    5.441n ±  0%        ~ (p=0.331 n=6)
MemmoveUnalignedDst/1               8.790n ±  0%    8.794n ±  0%        ~ (p=0.433 n=6)
MemmoveUnalignedDst/2               9.935n ±  0%    9.928n ±  0%        ~ (p=0.303 n=6)
MemmoveUnalignedDst/3               11.03n ±  0%    11.02n ±  1%        ~ (p=0.929 n=6)
MemmoveUnalignedDst/4               8.606n ±  0%    8.630n ±  0%        ~ (p=0.106 n=6)
MemmoveUnalignedDst/5               9.434n ±  0%    9.407n ±  0%   -0.28% (p=0.041 n=6)
MemmoveUnalignedDst/6               11.05n ±  1%    11.00n ±  0%   -0.45% (p=0.032 n=6)
MemmoveUnalignedDst/7               12.11n ±  1%    12.01n ±  0%   -0.78% (p=0.002 n=6)
MemmoveUnalignedDst/8               7.569n ±  1%    8.396n ±  0%  +10.91% (p=0.002 n=6)
MemmoveUnalignedDst/9               7.520n ±  1%    8.410n ±  0%  +11.84% (p=0.002 n=6)
MemmoveUnalignedDst/10              7.590n ±  2%    8.400n ±  0%  +10.67% (p=0.002 n=6)
MemmoveUnalignedDst/11              7.543n ±  1%    8.241n ±  1%   +9.25% (p=0.002 n=6)
MemmoveUnalignedDst/12              7.484n ±  3%    8.403n ±  0%  +12.27% (p=0.002 n=6)
MemmoveUnalignedDst/13              7.568n ±  2%    8.399n ±  0%  +10.98% (p=0.002 n=6)
MemmoveUnalignedDst/14              7.527n ±  1%    8.406n ±  0%  +11.69% (p=0.002 n=6)
MemmoveUnalignedDst/15              7.556n ±  2%    8.287n ±  0%   +9.68% (p=0.002 n=6)
MemmoveUnalignedDst/16              7.519n ±  1%    8.434n ±  0%  +12.16% (p=0.002 n=6)
MemmoveUnalignedDst/32              8.046n ±  1%    8.851n ±  0%   +9.99% (p=0.002 n=6)
MemmoveUnalignedDst/64              8.785n ±  0%    9.584n ±  0%   +9.09% (p=0.002 n=6)
MemmoveUnalignedDst/128             12.38n ±  0%    13.35n ±  0%   +7.88% (p=0.002 n=6)
MemmoveUnalignedDst/256             21.92n ±  0%    22.03n ±  0%   +0.50% (p=0.002 n=6)
MemmoveUnalignedDst/512             42.76n ±  3%    42.64n ±  4%        ~ (p=0.974 n=6)
MemmoveUnalignedDst/1024           101.10n ±  6%    94.31n ±  4%   -6.72% (p=0.026 n=6)
MemmoveUnalignedDst/2048            170.9n ±  0%    170.2n ±  0%   -0.41% (p=0.002 n=6)
MemmoveUnalignedDst/4096            344.1n ±  0%    344.4n ±  0%        ~ (p=0.234 n=6)
MemmoveUnalignedDstOverlap/32       8.388n ±  1%    9.205n ±  1%   +9.73% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/64       8.661n ±  0%    9.914n ±  1%  +14.46% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/128      10.94n ±  0%    12.53n ±  0%  +14.54% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/256      19.55n ±  0%    19.34n ±  0%   -1.13% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/512      30.68n ±  0%    31.20n ±  0%   +1.69% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/1024     57.55n ±  0%    57.59n ±  0%        ~ (p=0.260 n=6)
MemmoveUnalignedDstOverlap/2048     113.0n ±  0%    112.7n ±  0%   -0.22% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/4096     228.1n ±  0%    228.1n ±  0%        ~ (p=0.610 n=6)
MemmoveUnalignedSrc/0               5.853n ±  1%    5.771n ±  1%   -1.42% (p=0.002 n=6)
MemmoveUnalignedSrc/1               9.172n ±  0%    9.175n ±  0%        ~ (p=0.502 n=6)
MemmoveUnalignedSrc/2               10.29n ±  1%    10.29n ±  0%        ~ (p=0.558 n=6)
MemmoveUnalignedSrc/3               11.45n ±  0%    11.36n ±  0%   -0.79% (p=0.002 n=6)
MemmoveUnalignedSrc/4               9.021n ±  0%    8.993n ±  0%   -0.30% (p=0.041 n=6)
MemmoveUnalignedSrc/5               9.846n ±  0%    9.772n ±  0%   -0.75% (p=0.002 n=6)
MemmoveUnalignedSrc/6               11.42n ±  1%    11.34n ±  0%   -0.74% (p=0.004 n=6)
MemmoveUnalignedSrc/7               12.32n ±  1%    12.21n ±  1%   -0.89% (p=0.028 n=6)
MemmoveUnalignedSrc/8               7.861n ±  2%    8.629n ±  0%   +9.78% (p=0.002 n=6)
MemmoveUnalignedSrc/9               7.934n ±  1%    8.627n ±  1%   +8.73% (p=0.002 n=6)
MemmoveUnalignedSrc/10              7.953n ±  0%    8.630n ±  0%   +8.51% (p=0.002 n=6)
MemmoveUnalignedSrc/11              7.976n ±  1%    8.645n ±  0%   +8.37% (p=0.002 n=6)
MemmoveUnalignedSrc/12              7.930n ±  1%    8.619n ±  1%   +8.70% (p=0.002 n=6)
MemmoveUnalignedSrc/13              7.937n ±  1%    8.639n ±  1%   +8.84% (p=0.002 n=6)
MemmoveUnalignedSrc/14              7.959n ±  1%    8.656n ±  0%   +8.76% (p=0.002 n=6)
MemmoveUnalignedSrc/15              7.894n ±  2%    8.625n ±  0%   +9.27% (p=0.002 n=6)
MemmoveUnalignedSrc/16              7.898n ±  0%    8.665n ±  0%   +9.70% (p=0.002 n=6)
MemmoveUnalignedSrc/32              7.934n ±  1%    8.676n ±  1%   +9.35% (p=0.002 n=6)
MemmoveUnalignedSrc/64              7.898n ±  1%    9.500n ±  1%  +20.28% (p=0.002 n=6)
MemmoveUnalignedSrc/128             9.665n ±  0%   10.940n ±  1%  +13.20% (p=0.002 n=6)
MemmoveUnalignedSrc/256             17.00n ±  0%    16.79n ±  0%   -1.24% (p=0.002 n=6)
MemmoveUnalignedSrc/512             30.40n ±  0%    30.68n ±  0%   +0.90% (p=0.002 n=6)
MemmoveUnalignedSrc/1024            57.64n ±  0%    58.23n ±  0%   +1.03% (p=0.002 n=6)
MemmoveUnalignedSrc/2048            152.9n ±  7%    151.7n ± 13%        ~ (p=0.699 n=6)
MemmoveUnalignedSrc/4096            330.9n ±  6%    366.1n ± 17%  +10.62% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_16_0      11.490n ±  1%    9.302n ±  0%  -19.04% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_16_0      11.320n ±  0%    9.807n ±  1%  -13.37% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_16_1       8.837n ±  0%    9.262n ±  0%   +4.81% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_16_1       9.107n ±  0%    9.822n ±  0%   +7.86% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_16_4       8.817n ±  0%    9.257n ±  1%   +5.00% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_16_4       9.141n ±  1%    9.812n ±  0%   +7.34% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_16_7       8.829n ±  0%    9.280n ±  0%   +5.11% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_16_7       9.098n ±  1%    9.844n ±  1%   +8.19% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_64_0       12.44n ±  0%    10.23n ±  0%  -17.77% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_64_0       11.23n ±  0%    10.50n ±  1%   -6.46% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_64_1       9.688n ±  1%   10.735n ±  0%  +10.81% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_64_1       11.17n ±  0%    10.97n ±  0%   -1.79% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_64_4       9.209n ±  1%   10.330n ±  0%  +12.17% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_64_4       10.46n ±  0%    10.68n ±  1%   +2.10% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_64_7       9.691n ±  0%   10.735n ±  0%  +10.78% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_64_7       11.19n ±  0%    10.97n ±  0%   -2.01% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_256_0      19.32n ±  0%    19.09n ±  0%   -1.16% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_256_0      23.48n ±  0%    22.53n ±  0%   -4.05% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_256_1      23.76n ±  0%    24.82n ±  0%   +4.48% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_256_1      24.21n ±  0%    24.22n ±  0%        ~ (p=0.903 n=6)
MemmoveUnalignedSrcDst/f_256_4      22.79n ±  0%    22.93n ±  0%   +0.61% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_256_4      22.37n ±  1%    22.02n ±  0%   -1.52% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_256_7      23.76n ±  0%    24.86n ±  0%   +4.65% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_256_7      24.21n ±  0%    24.21n ±  0%        ~ (p=0.972 n=6)
MemmoveUnalignedSrcDst/f_4096_0     323.8n ±  8%    313.8n ± 14%        ~ (p=0.699 n=6)
MemmoveUnalignedSrcDst/b_4096_0     320.9n ±  0%    321.9n ±  1%   +0.30% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_4096_1     426.9n ± 16%    415.4n ±  9%        ~ (p=1.000 n=6)
MemmoveUnalignedSrcDst/b_4096_1     348.9n ±  0%    347.2n ±  1%        ~ (p=0.370 n=6)
MemmoveUnalignedSrcDst/f_4096_4     410.5n ±  6%    410.7n ± 10%        ~ (p=0.900 n=6)
MemmoveUnalignedSrcDst/b_4096_4     325.1n ±  1%    325.6n ±  1%        ~ (p=0.725 n=6)
MemmoveUnalignedSrcDst/f_4096_7     404.9n ±  6%    415.4n ± 15%        ~ (p=0.937 n=6)
MemmoveUnalignedSrcDst/b_4096_7     348.9n ±  0%    347.3n ±  2%        ~ (p=0.063 n=6)
MemmoveUnalignedSrcDst/f_65536_0    15.08µ ±  5%    15.57µ ± 18%   +3.29% (p=0.041 n=6)
MemmoveUnalignedSrcDst/b_65536_0    11.39µ ±  0%    11.40µ ±  2%        ~ (p=0.732 n=6)
MemmoveUnalignedSrcDst/f_65536_1    16.28µ ±  8%    16.26µ ±  9%        ~ (p=0.818 n=6)
MemmoveUnalignedSrcDst/b_65536_1    11.50µ ±  0%    11.43µ ±  0%   -0.65% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_65536_4    16.77µ ±  5%    17.42µ ±  6%        ~ (p=0.093 n=6)
MemmoveUnalignedSrcDst/b_65536_4    11.38µ ±  0%    11.30µ ±  0%   -0.76% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_65536_7    16.20µ ± 13%    17.03µ ± 12%        ~ (p=0.180 n=6)
MemmoveUnalignedSrcDst/b_65536_7    11.53µ ±  1%    11.46µ ±  0%   -0.63% (p=0.009 n=6)
MemmoveUnalignedSrcOverlap/32       8.370n ±  1%    9.185n ±  0%   +9.74% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/64       8.443n ±  1%    9.911n ±  1%  +17.39% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/128      12.21n ±  0%    13.12n ±  1%   +7.45% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/256      25.49n ±  0%    24.60n ±  0%   -3.53% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/512      44.54n ±  0%    44.43n ±  0%   -0.26% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/1024     86.08n ±  0%    85.97n ±  0%        ~ (p=0.078 n=6)
MemmoveUnalignedSrcOverlap/2048     170.2n ±  0%    170.4n ±  0%        ~ (p=0.431 n=6)
MemmoveUnalignedSrcOverlap/4096     357.1n ±  1%    351.5n ±  0%   -1.58% (p=0.002 n=6)
MemmoveKnownSize112                 51.18n ±  0%    46.63n ±  0%   -8.90% (p=0.002 n=6)
MemmoveKnownSize128                 53.40n ±  0%    53.17n ±  0%   -0.43% (p=0.002 n=6)
MemmoveKnownSize192                 86.99n ±  0%    86.23n ±  1%        ~ (p=0.093 n=6)
MemmoveKnownSize248                 113.2n ±  1%    109.8n ±  0%   -3.00% (p=0.002 n=6)
MemmoveKnownSize256                 112.8n ±  0%    112.8n ±  0%        ~ (p=0.736 n=6)
MemmoveKnownSize512                 228.1n ±  2%    222.0n ±  0%   -2.67% (p=0.002 n=6)
MemmoveKnownSize1024                446.4n ±  4%    440.1n ±  0%   -1.42% (p=0.002 n=6)
geomean                             31.98n          30.94n         -3.24%

                                 │   old_sg.txt   │               new_sg.txt               │
                                 │      B/s       │      B/s        vs base                │
Memmove/1                           91.77Mi ±  0%    91.73Mi ±  0%         ~ (p=0.617 n=6)
Memmove/2                           159.7Mi ±  0%    159.8Mi ±  0%         ~ (p=0.139 n=6)
Memmove/3                           212.2Mi ±  0%    212.1Mi ±  0%         ~ (p=0.699 n=6)
Memmove/4                           425.0Mi ±  1%    422.8Mi ±  1%         ~ (p=0.394 n=6)
Memmove/5                           444.0Mi ±  0%    444.0Mi ±  0%         ~ (p=0.699 n=6)
Memmove/6                           466.3Mi ±  0%    466.0Mi ±  1%         ~ (p=0.937 n=6)
Memmove/7                           483.8Mi ±  0%    483.2Mi ±  0%         ~ (p=0.180 n=6)
Memmove/8                           800.2Mi ±  1%    866.1Mi ±  1%    +8.24% (p=0.002 n=6)
Memmove/9                          1065.0Mi ±  1%    975.4Mi ±  1%    -8.42% (p=0.002 n=6)
Memmove/10                          1.163Gi ±  1%    1.059Gi ±  1%    -8.90% (p=0.002 n=6)
Memmove/11                          1.274Gi ±  1%    1.164Gi ±  1%    -8.64% (p=0.002 n=6)
Memmove/12                          1.390Gi ±  0%    1.271Gi ±  1%    -8.58% (p=0.002 n=6)
Memmove/13                          1.505Gi ±  1%    1.373Gi ±  0%    -8.80% (p=0.002 n=6)
Memmove/14                          1.616Gi ±  0%    1.482Gi ±  0%    -8.28% (p=0.002 n=6)
Memmove/15                          1.736Gi ±  1%    1.591Gi ±  0%    -8.37% (p=0.002 n=6)
Memmove/16                          1.475Gi ±  0%    1.689Gi ±  1%   +14.52% (p=0.002 n=6)
Memmove/32                          2.613Gi ±  0%    3.379Gi ±  0%   +29.31% (p=0.002 n=6)
Memmove/64                          5.250Gi ±  0%    6.482Gi ±  0%   +23.46% (p=0.002 n=6)
Memmove/128                         14.04Gi ±  0%    11.19Gi ±  1%   -20.32% (p=0.002 n=6)
Memmove/256                         15.23Gi ± 44%    15.61Gi ±  0%    +2.55% (p=0.002 n=6)
Memmove/512                         7.063Gi ±  6%   16.698Gi ±  1%  +136.41% (p=0.002 n=6)
Memmove/1024                        2.613Gi ±  3%   16.474Gi ± 10%  +530.57% (p=0.002 n=6)
Memmove/2048                        2.385Gi ±  6%   14.305Gi ±  9%  +499.77% (p=0.002 n=6)
Memmove/4096                        1.649Gi ±  6%   10.675Gi ± 21%  +547.43% (p=0.002 n=6)
MemmoveOverlap/32                   1.189Gi ±  1%    3.100Gi ±  1%  +160.68% (p=0.002 n=6)
MemmoveOverlap/64                   3.100Gi ±  1%    5.826Gi ±  1%   +87.96% (p=0.002 n=6)
MemmoveOverlap/128                 10.322Gi ±  0%    9.845Gi ±  1%    -4.62% (p=0.002 n=6)
MemmoveOverlap/256                  14.68Gi ±  0%    14.68Gi ±  0%         ~ (p=0.589 n=6)
MemmoveOverlap/512                  16.36Gi ±  0%    16.56Gi ±  0%    +1.25% (p=0.002 n=6)
MemmoveOverlap/1024                 17.06Gi ±  0%    17.15Gi ±  0%    +0.53% (p=0.002 n=6)
MemmoveOverlap/2048                 17.90Gi ±  0%    17.85Gi ±  0%    -0.30% (p=0.002 n=6)
MemmoveOverlap/4096                 17.46Gi ±  0%    17.26Gi ±  0%    -1.17% (p=0.002 n=6)
MemmoveUnalignedDst/1               108.5Mi ±  0%    108.4Mi ±  0%         ~ (p=0.561 n=6)
MemmoveUnalignedDst/2               192.0Mi ±  0%    192.1Mi ±  0%         ~ (p=0.229 n=6)
MemmoveUnalignedDst/3               259.3Mi ±  0%    259.6Mi ±  1%         ~ (p=0.699 n=6)
MemmoveUnalignedDst/4               443.3Mi ±  0%    442.0Mi ±  0%         ~ (p=0.132 n=6)
MemmoveUnalignedDst/5               505.4Mi ±  0%    506.9Mi ±  0%    +0.28% (p=0.041 n=6)
MemmoveUnalignedDst/6               517.9Mi ±  1%    520.1Mi ±  0%    +0.42% (p=0.024 n=6)
MemmoveUnalignedDst/7               551.5Mi ±  1%    555.7Mi ±  1%    +0.77% (p=0.002 n=6)
MemmoveUnalignedDst/8              1007.9Mi ±  1%    908.7Mi ±  0%    -9.84% (p=0.002 n=6)
MemmoveUnalignedDst/9              1141.4Mi ±  1%   1020.6Mi ±  0%   -10.59% (p=0.002 n=6)
MemmoveUnalignedDst/10              1.227Gi ±  2%    1.109Gi ±  0%    -9.65% (p=0.002 n=6)
MemmoveUnalignedDst/11              1.358Gi ±  1%    1.243Gi ±  1%    -8.47% (p=0.002 n=6)
MemmoveUnalignedDst/12              1.493Gi ±  2%    1.330Gi ±  0%   -10.94% (p=0.002 n=6)
MemmoveUnalignedDst/13              1.600Gi ±  2%    1.441Gi ±  0%    -9.89% (p=0.002 n=6)
MemmoveUnalignedDst/14              1.732Gi ±  1%    1.551Gi ±  0%   -10.46% (p=0.002 n=6)
MemmoveUnalignedDst/15              1.849Gi ±  2%    1.686Gi ±  0%    -8.83% (p=0.002 n=6)
MemmoveUnalignedDst/16              1.982Gi ±  1%    1.767Gi ±  0%   -10.84% (p=0.002 n=6)
MemmoveUnalignedDst/32              3.704Gi ±  1%    3.367Gi ±  0%    -9.09% (p=0.002 n=6)
MemmoveUnalignedDst/64              6.785Gi ±  0%    6.219Gi ±  0%    -8.33% (p=0.002 n=6)
MemmoveUnalignedDst/128             9.634Gi ±  0%    8.927Gi ±  0%    -7.34% (p=0.002 n=6)
MemmoveUnalignedDst/256             10.88Gi ±  0%    10.82Gi ±  0%    -0.48% (p=0.002 n=6)
MemmoveUnalignedDst/512             11.15Gi ±  3%    11.18Gi ±  4%         ~ (p=1.000 n=6)
MemmoveUnalignedDst/1024            9.435Gi ±  7%   10.112Gi ±  4%    +7.18% (p=0.026 n=6)
MemmoveUnalignedDst/2048            11.16Gi ±  0%    11.21Gi ±  0%    +0.42% (p=0.002 n=6)
MemmoveUnalignedDst/4096            11.09Gi ±  0%    11.08Gi ±  0%         ~ (p=0.310 n=6)
MemmoveUnalignedDstOverlap/32       3.553Gi ±  1%    3.238Gi ±  1%    -8.87% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/64       6.882Gi ±  0%    6.013Gi ±  1%   -12.63% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/128     10.903Gi ±  0%    9.517Gi ±  0%   -12.71% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/256      12.19Gi ±  0%    12.33Gi ±  0%    +1.14% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/512      15.54Gi ±  0%    15.28Gi ±  0%    -1.66% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/1024     16.57Gi ±  0%    16.56Gi ±  0%         ~ (p=0.310 n=6)
MemmoveUnalignedDstOverlap/2048     16.89Gi ±  0%    16.93Gi ±  0%    +0.24% (p=0.002 n=6)
MemmoveUnalignedDstOverlap/4096     16.72Gi ±  0%    16.72Gi ±  0%         ~ (p=0.589 n=6)
MemmoveUnalignedSrc/1               104.0Mi ±  0%    103.9Mi ±  0%         ~ (p=0.504 n=6)
MemmoveUnalignedSrc/2               185.2Mi ±  1%    185.4Mi ±  0%         ~ (p=0.563 n=6)
MemmoveUnalignedSrc/3               250.0Mi ±  0%    252.0Mi ±  0%    +0.77% (p=0.002 n=6)
MemmoveUnalignedSrc/4               422.9Mi ±  0%    424.2Mi ±  0%    +0.30% (p=0.041 n=6)
MemmoveUnalignedSrc/5               484.3Mi ±  0%    487.9Mi ±  0%    +0.75% (p=0.002 n=6)
MemmoveUnalignedSrc/6               501.0Mi ±  1%    504.8Mi ±  0%    +0.75% (p=0.004 n=6)
MemmoveUnalignedSrc/7               542.2Mi ±  1%    546.9Mi ±  1%    +0.87% (p=0.028 n=6)
MemmoveUnalignedSrc/8               970.6Mi ±  2%    884.2Mi ±  0%    -8.90% (p=0.002 n=6)
MemmoveUnalignedSrc/9              1081.8Mi ±  1%    995.0Mi ±  1%    -8.03% (p=0.002 n=6)
MemmoveUnalignedSrc/10              1.171Gi ±  0%    1.079Gi ±  0%    -7.85% (p=0.002 n=6)
MemmoveUnalignedSrc/11              1.284Gi ±  1%    1.185Gi ±  0%    -7.73% (p=0.002 n=6)
MemmoveUnalignedSrc/12              1.409Gi ±  1%    1.297Gi ±  1%    -8.01% (p=0.002 n=6)
MemmoveUnalignedSrc/13              1.525Gi ±  1%    1.401Gi ±  1%    -8.12% (p=0.002 n=6)
MemmoveUnalignedSrc/14              1.638Gi ±  1%    1.506Gi ±  0%    -8.05% (p=0.002 n=6)
MemmoveUnalignedSrc/15              1.770Gi ±  2%    1.620Gi ±  0%    -8.48% (p=0.002 n=6)
MemmoveUnalignedSrc/16              1.887Gi ±  0%    1.720Gi ±  0%    -8.85% (p=0.002 n=6)
MemmoveUnalignedSrc/32              3.756Gi ±  1%    3.435Gi ±  1%    -8.55% (p=0.002 n=6)
MemmoveUnalignedSrc/64              7.546Gi ±  1%    6.274Gi ±  1%   -16.86% (p=0.002 n=6)
MemmoveUnalignedSrc/128             12.33Gi ±  0%    10.90Gi ±  0%   -11.63% (p=0.002 n=6)
MemmoveUnalignedSrc/256             14.03Gi ±  0%    14.20Gi ±  0%    +1.24% (p=0.002 n=6)
MemmoveUnalignedSrc/512             15.69Gi ±  0%    15.54Gi ±  0%    -0.91% (p=0.002 n=6)
MemmoveUnalignedSrc/1024            16.55Gi ±  0%    16.38Gi ±  0%    -1.02% (p=0.002 n=6)
MemmoveUnalignedSrc/2048            12.48Gi ±  7%    12.58Gi ± 15%         ~ (p=0.699 n=6)
MemmoveUnalignedSrc/4096            11.53Gi ±  6%    10.42Gi ± 14%    -9.60% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_16_0       1.297Gi ±  1%    1.602Gi ±  0%   +23.50% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_16_0       1.316Gi ±  0%    1.519Gi ±  1%   +15.43% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_16_1       1.686Gi ±  0%    1.609Gi ±  0%    -4.60% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_16_1       1.636Gi ±  1%    1.517Gi ±  0%    -7.29% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_16_4       1.690Gi ±  0%    1.610Gi ±  1%    -4.76% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_16_4       1.630Gi ±  1%    1.519Gi ±  0%    -6.84% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_16_7       1.688Gi ±  0%    1.606Gi ±  0%    -4.87% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_16_7       1.638Gi ±  1%    1.514Gi ±  1%    -7.57% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_64_0       4.791Gi ±  0%    5.825Gi ±  0%   +21.59% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_64_0       5.306Gi ±  0%    5.675Gi ±  1%    +6.94% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_64_1       6.153Gi ±  1%    5.554Gi ±  0%    -9.73% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_64_1       5.340Gi ±  0%    5.437Gi ±  0%    +1.82% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_64_4       6.473Gi ±  1%    5.771Gi ±  0%   -10.85% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_64_4       5.696Gi ±  0%    5.579Gi ±  1%    -2.06% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_64_7       6.151Gi ±  0%    5.552Gi ±  0%    -9.73% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_64_7       5.328Gi ±  0%    5.436Gi ±  0%    +2.04% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_256_0      12.34Gi ±  0%    12.49Gi ±  0%    +1.21% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_256_0      10.15Gi ±  0%    10.58Gi ±  0%    +4.22% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_256_1     10.036Gi ±  0%    9.603Gi ±  0%    -4.31% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_256_1      9.851Gi ±  0%    9.842Gi ±  0%         ~ (p=0.818 n=6)
MemmoveUnalignedSrcDst/f_256_4      10.46Gi ±  0%    10.40Gi ±  0%    -0.60% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_256_4      10.66Gi ±  1%    10.82Gi ±  0%    +1.54% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_256_7     10.036Gi ±  0%    9.590Gi ±  0%    -4.44% (p=0.002 n=6)
MemmoveUnalignedSrcDst/b_256_7      9.847Gi ±  0%    9.845Gi ±  0%         ~ (p=1.000 n=6)
MemmoveUnalignedSrcDst/f_4096_0     11.78Gi ±  9%    12.16Gi ± 13%         ~ (p=0.699 n=6)
MemmoveUnalignedSrcDst/b_4096_0     11.89Gi ±  0%    11.85Gi ±  1%    -0.31% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_4096_1     8.949Gi ± 19%    9.185Gi ±  8%         ~ (p=1.000 n=6)
MemmoveUnalignedSrcDst/b_4096_1     10.93Gi ±  0%    10.99Gi ±  1%         ~ (p=0.394 n=6)
MemmoveUnalignedSrcDst/f_4096_4     9.295Gi ±  6%    9.290Gi ±  9%         ~ (p=0.937 n=6)
MemmoveUnalignedSrcDst/b_4096_4     11.73Gi ±  1%    11.71Gi ±  1%         ~ (p=0.818 n=6)
MemmoveUnalignedSrcDst/f_4096_7     9.421Gi ±  5%    9.188Gi ± 13%         ~ (p=0.937 n=6)
MemmoveUnalignedSrcDst/b_4096_7     10.94Gi ±  0%    10.98Gi ±  2%         ~ (p=0.065 n=6)
MemmoveUnalignedSrcDst/f_65536_0    4.048Gi ±  5%    3.919Gi ± 15%    -3.18% (p=0.041 n=6)
MemmoveUnalignedSrcDst/b_65536_0    5.357Gi ±  0%    5.356Gi ±  2%         ~ (p=0.818 n=6)
MemmoveUnalignedSrcDst/f_65536_1    3.748Gi ±  8%    3.753Gi ± 10%         ~ (p=0.818 n=6)
MemmoveUnalignedSrcDst/b_65536_1    5.306Gi ±  0%    5.340Gi ±  0%    +0.65% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_65536_4    3.639Gi ±  5%    3.504Gi ±  6%         ~ (p=0.093 n=6)
MemmoveUnalignedSrcDst/b_65536_4    5.361Gi ±  0%    5.403Gi ±  0%    +0.77% (p=0.002 n=6)
MemmoveUnalignedSrcDst/f_65536_7    3.767Gi ± 12%    3.584Gi ± 14%         ~ (p=0.180 n=6)
MemmoveUnalignedSrcDst/b_65536_7    5.294Gi ±  1%    5.328Gi ±  0%    +0.63% (p=0.009 n=6)
MemmoveUnalignedSrcOverlap/32       3.560Gi ±  1%    3.244Gi ±  0%    -8.87% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/64       7.060Gi ±  1%    6.014Gi ±  1%   -14.81% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/128      9.758Gi ±  0%    9.084Gi ±  1%    -6.91% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/256      9.353Gi ±  0%    9.694Gi ±  0%    +3.65% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/512      10.71Gi ±  0%    10.73Gi ±  0%    +0.26% (p=0.002 n=6)
MemmoveUnalignedSrcOverlap/1024     11.08Gi ±  0%    11.09Gi ±  0%         ~ (p=0.093 n=6)
MemmoveUnalignedSrcOverlap/2048     11.20Gi ±  0%    11.19Gi ±  0%         ~ (p=0.485 n=6)
MemmoveUnalignedSrcOverlap/4096     10.68Gi ±  1%    10.85Gi ±  0%    +1.62% (p=0.002 n=6)
MemmoveKnownSize112                 2.038Gi ±  0%    2.237Gi ±  0%    +9.77% (p=0.002 n=6)
MemmoveKnownSize128                 2.232Gi ±  0%    2.242Gi ±  0%    +0.43% (p=0.002 n=6)
MemmoveKnownSize192                 2.055Gi ±  0%    2.073Gi ±  1%         ~ (p=0.093 n=6)
MemmoveKnownSize248                 2.039Gi ±  1%    2.103Gi ±  0%    +3.09% (p=0.002 n=6)
MemmoveKnownSize256                 2.113Gi ±  0%    2.114Gi ±  0%         ~ (p=0.699 n=6)
MemmoveKnownSize512                 2.091Gi ±  2%    2.148Gi ±  0%    +2.74% (p=0.002 n=6)
MemmoveKnownSize1024                2.136Gi ±  4%    2.167Gi ±  0%    +1.44% (p=0.002 n=6)
geomean                             3.020Gi          3.123Gi          +3.41%
```

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required