### PR TITLE
 cmd/compile/internal/riscv64: ssa memcombine when fast unaligned

### DIFF
--- a/src/cmd/compile/internal/riscv64/ssa.go
+++ b/src/cmd/compile/internal/riscv64/ssa.go
@@ -815,28 +815,7 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		var off int64
 		tmp := int16(riscv.REG_X5)
 		if buildcfg.GORISCV64EXT.MisalignedFast {
-			// On cores with fast misaligned accesses, choose move width from the
-			// remaining size directly to minimize the number of move instructions.
-			for n > 0 {
-				switch {
-				case n >= 8:
-					moveOp(s, riscv.AMOV, dst, src, tmp, off)
-					off += 8
-					n -= 8
-				case n >= 4:
-					moveOp(s, riscv.AMOVW, dst, src, tmp, off)
-					off += 4
-					n -= 4
-				case n >= 2:
-					moveOp(s, riscv.AMOVH, dst, src, tmp, off)
-					off += 2
-					n -= 2
-				default:
-					moveOp(s, riscv.AMOVB, dst, src, tmp, off)
-					off++
-					n--
-				}
-			}
+			emitDynamicMoves(s, dst, src, tmp, off, n)
 		} else {
 			for n >= sz {
 				moveOp(s, mov, dst, src, tmp, off)
@@ -865,12 +844,63 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		sc := v.AuxValAndOff()
 		n := sc.Val64()
 		mov, sz := largestMove(sc.Off64())
+		tmp := int16(riscv.REG_X5)
+
+		if buildcfg.GORISCV64EXT.MisalignedFast {
+			//   n < 64:        fully unrolled with dynamic 8/4/2/1 moves
+			//   64 <= n < 128: unroll 64 bytes + unroll remainder
+			//   n >= 128:      loop by 64-byte chunks + unroll remainder
+			const chunk = int64(64)
+			if n < chunk {
+				emitDynamicMoves(s, dst, src, tmp, 0, n)
+				break
+			}
+			if n < 2*chunk {
+				emitDynamicMoves(s, dst, src, tmp, 0, chunk)
+				emitDynamicMoves(s, dst, src, tmp, chunk, n-chunk)
+				break
+			}
+
+			p := s.Prog(riscv.AADD)
+			p.From.Type = obj.TYPE_CONST
+			p.From.Offset = n - n%chunk
+			p.Reg = src
+			p.To.Type = obj.TYPE_REG
+			p.To.Reg = riscv.REG_X6
+
+			loopHead := s.Prog(obj.ANOP)
+			emitDynamicMoves(s, dst, src, tmp, 0, chunk)
+
+			p1 := s.Prog(riscv.AADD)
+			p1.From.Type = obj.TYPE_CONST
+			p1.From.Offset = chunk
+			p1.To.Type = obj.TYPE_REG
+			p1.To.Reg = src
+
+			p2 := s.Prog(riscv.AADD)
+			p2.From.Type = obj.TYPE_CONST
+			p2.From.Offset = chunk
+			p2.To.Type = obj.TYPE_REG
+			p2.To.Reg = dst
+
+			p3 := s.Prog(riscv.ABNE)
+			p3.From.Reg = riscv.REG_X6
+			p3.From.Type = obj.TYPE_REG
+			p3.Reg = src
+			p3.To.Type = obj.TYPE_BRANCH
+			p3.To.SetTarget(loopHead)
+
+			if rem := n % chunk; rem > 0 {
+				emitDynamicMoves(s, dst, src, tmp, 0, rem)
+			}
+			break
+		}
+
 		chunk := 8 * sz
 
 		if n <= 3*chunk {
 			v.Fatalf("MoveLoop too small:%d, expect:%d", n, 3*chunk)
 		}
-		tmp := int16(riscv.REG_X5)
 
 		p := s.Prog(riscv.AADD)
 		p.From.Type = obj.TYPE_CONST
@@ -1080,7 +1110,6 @@ func zeroOp(s *ssagen.State, mov obj.As, reg int16, off int64) {
 	p.To.Type = obj.TYPE_MEM
 	p.To.Reg = reg
 	p.To.Offset = off
-	return
 }
 
 func moveOp(s *ssagen.State, mov obj.As, dst int16, src int16, tmp int16, off int64) {
@@ -1097,6 +1126,27 @@ func moveOp(s *ssagen.State, mov obj.As, dst int16, src int16, tmp int16, off in
 	p1.To.Type = obj.TYPE_MEM
 	p1.To.Reg = dst
 	p1.To.Offset = off
+}
 
-	return
+func emitDynamicMoves(s *ssagen.State, dst int16, src int16, tmp int16, off int64, n int64) {
+	for n > 0 {
+		switch {
+		case n >= 8:
+			moveOp(s, riscv.AMOV, dst, src, tmp, off)
+			off += 8
+			n -= 8
+		case n >= 4:
+			moveOp(s, riscv.AMOVW, dst, src, tmp, off)
+			off += 4
+			n -= 4
+		case n >= 2:
+			moveOp(s, riscv.AMOVH, dst, src, tmp, off)
+			off += 2
+			n -= 2
+		default:
+			moveOp(s, riscv.AMOVB, dst, src, tmp, off)
+			off++
+			n--
+		}
+	}
 }

--- a/src/cmd/compile/internal/riscv64/ssa.go
+++ b/src/cmd/compile/internal/riscv64/ssa.go
@@ -1161,6 +1161,7 @@ func zeroOp(s *ssagen.State, mov obj.As, reg int16, off int64) {
 	p.To.Type = obj.TYPE_MEM
 	p.To.Reg = reg
 	p.To.Offset = off
+	return
 }
 
 func moveOp(s *ssagen.State, mov obj.As, dst int16, src int16, tmp int16, off int64) {
@@ -1177,6 +1178,7 @@ func moveOp(s *ssagen.State, mov obj.As, dst int16, src int16, tmp int16, off in
 	p1.To.Type = obj.TYPE_MEM
 	p1.To.Reg = dst
 	p1.To.Offset = off
+	return
 }
 
 func emitDynamicMoves(s *ssagen.State, dst int16, src int16, tmp int16, off int64, n int64) {
@@ -1200,6 +1202,7 @@ func emitDynamicMoves(s *ssagen.State, dst int16, src int16, tmp int16, off int6
 			n--
 		}
 	}
+	return
 }
 
 func emitDynamicZeros(s *ssagen.State, ptr int16, off int64, n int64) {
@@ -1223,4 +1226,5 @@ func emitDynamicZeros(s *ssagen.State, ptr int16, off int64, n int64) {
 			n--
 		}
 	}
+	return
 }

--- a/src/cmd/compile/internal/riscv64/ssa.go
+++ b/src/cmd/compile/internal/riscv64/ssa.go
@@ -814,20 +814,45 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 
 		var off int64
 		tmp := int16(riscv.REG_X5)
-		for n >= sz {
-			moveOp(s, mov, dst, src, tmp, off)
-			off += sz
-			n -= sz
-		}
-
-		for i := len(fracMovOps) - 1; i >= 0; i-- {
-			tsz := int64(1 << i)
-			if n < tsz {
-				continue
+		if buildcfg.GORISCV64EXT.MisalignedFast {
+			// On cores with fast misaligned accesses, choose move width from the
+			// remaining size directly to minimize the number of move instructions.
+			for n > 0 {
+				switch {
+				case n >= 8:
+					moveOp(s, riscv.AMOV, dst, src, tmp, off)
+					off += 8
+					n -= 8
+				case n >= 4:
+					moveOp(s, riscv.AMOVW, dst, src, tmp, off)
+					off += 4
+					n -= 4
+				case n >= 2:
+					moveOp(s, riscv.AMOVH, dst, src, tmp, off)
+					off += 2
+					n -= 2
+				default:
+					moveOp(s, riscv.AMOVB, dst, src, tmp, off)
+					off++
+					n--
+				}
 			}
-			moveOp(s, fracMovOps[i], dst, src, tmp, off)
-			off += tsz
-			n -= tsz
+		} else {
+			for n >= sz {
+				moveOp(s, mov, dst, src, tmp, off)
+				off += sz
+				n -= sz
+			}
+
+			for i := len(fracMovOps) - 1; i >= 0; i-- {
+				tsz := int64(1 << i)
+				if n < tsz {
+					continue
+				}
+				moveOp(s, fracMovOps[i], dst, src, tmp, off)
+				off += tsz
+				n -= tsz
+			}
 		}
 
 	case ssa.OpRISCV64LoweredMoveLoop:

--- a/src/cmd/compile/internal/riscv64/ssa.go
+++ b/src/cmd/compile/internal/riscv64/ssa.go
@@ -728,20 +728,24 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 
 		// mov	ZERO, (offset)(Rarg0)
 		var off int64
-		for n >= sz {
-			zeroOp(s, mov, ptr, off)
-			off += sz
-			n -= sz
-		}
-
-		for i := len(fracMovOps) - 1; i >= 0; i-- {
-			tsz := int64(1 << i)
-			if n < tsz {
-				continue
+		if buildcfg.GORISCV64EXT.MisalignedFast {
+			emitDynamicZeros(s, ptr, off, n)
+		} else {
+			for n >= sz {
+				zeroOp(s, mov, ptr, off)
+				off += sz
+				n -= sz
 			}
-			zeroOp(s, fracMovOps[i], ptr, off)
-			off += tsz
-			n -= tsz
+
+			for i := len(fracMovOps) - 1; i >= 0; i-- {
+				tsz := int64(1 << i)
+				if n < tsz {
+					continue
+				}
+				zeroOp(s, fracMovOps[i], ptr, off)
+				off += tsz
+				n -= tsz
+			}
 		}
 
 	case ssa.OpRISCV64LoweredZeroLoop:
@@ -749,6 +753,53 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		sc := v.AuxValAndOff()
 		n := sc.Val64()
 		mov, sz := largestMove(sc.Off64())
+		if buildcfg.GORISCV64EXT.MisalignedFast {
+			// Misaligned-fast path:
+			//   n < 64:        fully unrolled with dynamic 8/4/2/1 zero stores
+			//   64 <= n < 128: unroll 64 bytes + unroll remainder
+			//   n >= 128:      loop by 64-byte chunks + unroll remainder
+			const chunk = int64(64)
+			if n < chunk {
+				emitDynamicZeros(s, ptr, 0, n)
+				break
+			}
+			if n < 2*chunk {
+				emitDynamicZeros(s, ptr, 0, chunk)
+				emitDynamicZeros(s, ptr, chunk, n-chunk)
+				break
+			}
+
+			tmp := v.RegTmp()
+
+			p := s.Prog(riscv.AADD)
+			p.From.Type = obj.TYPE_CONST
+			p.From.Offset = n - n%chunk
+			p.Reg = ptr
+			p.To.Type = obj.TYPE_REG
+			p.To.Reg = tmp
+
+			loopHead := s.Prog(obj.ANOP)
+			emitDynamicZeros(s, ptr, 0, chunk)
+
+			p2 := s.Prog(riscv.AADD)
+			p2.From.Type = obj.TYPE_CONST
+			p2.From.Offset = chunk
+			p2.To.Type = obj.TYPE_REG
+			p2.To.Reg = ptr
+
+			p3 := s.Prog(riscv.ABNE)
+			p3.From.Reg = tmp
+			p3.From.Type = obj.TYPE_REG
+			p3.Reg = ptr
+			p3.To.Type = obj.TYPE_BRANCH
+			p3.To.SetTarget(loopHead)
+
+			if rem := n % chunk; rem > 0 {
+				emitDynamicZeros(s, ptr, 0, rem)
+			}
+			break
+		}
+
 		chunk := 8 * sz
 
 		if n <= 3*chunk {
@@ -1145,6 +1196,29 @@ func emitDynamicMoves(s *ssagen.State, dst int16, src int16, tmp int16, off int6
 			n -= 2
 		default:
 			moveOp(s, riscv.AMOVB, dst, src, tmp, off)
+			off++
+			n--
+		}
+	}
+}
+
+func emitDynamicZeros(s *ssagen.State, ptr int16, off int64, n int64) {
+	for n > 0 {
+		switch {
+		case n >= 8:
+			zeroOp(s, riscv.AMOV, ptr, off)
+			off += 8
+			n -= 8
+		case n >= 4:
+			zeroOp(s, riscv.AMOVW, ptr, off)
+			off += 4
+			n -= 4
+		case n >= 2:
+			zeroOp(s, riscv.AMOVH, ptr, off)
+			off += 2
+			n -= 2
+		default:
+			zeroOp(s, riscv.AMOVB, ptr, off)
 			off++
 			n--
 		}

--- a/src/runtime/memmove_test.go
+++ b/src/runtime/memmove_test.go
@@ -1558,21 +1558,6 @@ func BenchmarkMemmoveKnownSize127(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSize128(b *testing.B) {
-	type T struct {
-		x [128]int8
-	}
-	p := &T{}
-	q := &T{}
-
-	b.SetBytes(int64(unsafe.Sizeof(T{})))
-	for i := 0; i < b.N; i++ {
-		*p = *q
-	}
-
-	memclrSink = p.x[:]
-}
-
 func BenchmarkMemmoveKnownSize160(b *testing.B) {
 	type T struct {
 		x [160]int8

--- a/src/runtime/memmove_test.go
+++ b/src/runtime/memmove_test.go
@@ -1315,6 +1315,324 @@ func BenchmarkMemmoveKnownSizeIs24(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
+func BenchmarkMemmoveKnownSizeIs56Loop(b *testing.B) {
+	type T struct {
+		x [56]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs60Loop(b *testing.B) {
+	type T struct {
+		x [60]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs62Loop(b *testing.B) {
+	type T struct {
+		x [62]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs63Loop(b *testing.B) {
+	type T struct {
+		x [63]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs64Loop(b *testing.B) {
+	type T struct {
+		x [64]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs127Loop(b *testing.B) {
+	type T struct {
+		x [127]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs128Loop(b *testing.B) {
+	type T struct {
+		x [128]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs160Loop(b *testing.B) {
+	type T struct {
+		x [160]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs164Loop(b *testing.B) {
+	type T struct {
+		x [164]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+// Unaligned versions of the Loop benchmarks.
+// These use addresses that are 1-byte aligned but not 8-byte aligned.
+
+func BenchmarkMemmoveKnownSizeIs56LoopUnaligned(b *testing.B) {
+	type T struct {
+		x [56]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs60LoopUnaligned(b *testing.B) {
+	type T struct {
+		x [60]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs62LoopUnaligned(b *testing.B) {
+	type T struct {
+		x [62]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs63LoopUnaligned(b *testing.B) {
+	type T struct {
+		x [63]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs64LoopUnaligned(b *testing.B) {
+	type T struct {
+		x [64]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs127LoopUnaligned(b *testing.B) {
+	type T struct {
+		x [127]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs128LoopUnaligned(b *testing.B) {
+	type T struct {
+		x [128]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs160LoopUnaligned(b *testing.B) {
+	type T struct {
+		x [160]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs164LoopUnaligned(b *testing.B) {
+	type T struct {
+		x [164]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
 func BenchmarkMemmoveKnownSizeIs8Unaligned(b *testing.B) {
 	type T struct {
 		x [8]int8

--- a/src/runtime/memmove_test.go
+++ b/src/runtime/memmove_test.go
@@ -1224,3 +1224,213 @@ func BenchmarkMemmoveKnownSize1024(b *testing.B) {
 
 	memclrSink = p.x[:]
 }
+
+func BenchmarkMemmoveKnownSizeIs8(b *testing.B) {
+	type T struct {
+		x [8]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs12(b *testing.B) {
+	type T struct {
+		x [12]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs14(b *testing.B) {
+	type T struct {
+		x [14]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs15(b *testing.B) {
+	type T struct {
+		x [15]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs16(b *testing.B) {
+	type T struct {
+		x [16]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs24(b *testing.B) {
+	type T struct {
+		x [24]int8
+	}
+	p := &T{}
+	q := &T{}
+
+	b.SetBytes(int64(unsafe.Sizeof(T{})))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs8Unaligned(b *testing.B) {
+	type T struct {
+		x [8]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs12Unaligned(b *testing.B) {
+	type T struct {
+		x [12]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs14Unaligned(b *testing.B) {
+	type T struct {
+		x [14]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs15Unaligned(b *testing.B) {
+	type T struct {
+		x [15]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs16Unaligned(b *testing.B) {
+	type T struct {
+		x [16]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}
+
+func BenchmarkMemmoveKnownSizeIs24Unaligned(b *testing.B) {
+	type T struct {
+		x [24]int8
+	}
+	size := unsafe.Sizeof(T{})
+	buf := make([]byte, size*2+8)
+	aligned := uintptr(unsafe.Pointer(&buf[0]))
+	aligned = (aligned + 7) &^ uintptr(7) // 8-byte align
+	unaligned := aligned + 1              // 1-byte offset, not 8-byte aligned
+	p := (*T)(unsafe.Pointer(unaligned))
+	q := (*T)(unsafe.Pointer(unaligned + size)) // Ensure enough space between src and dst
+
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		*p = *q
+	}
+
+	memclrSink = p.x[:]
+}

--- a/src/runtime/memmove_test.go
+++ b/src/runtime/memmove_test.go
@@ -709,6 +709,159 @@ func BenchmarkClearFat1040(b *testing.B) {
 	}
 }
 
+func ptr8Unaligned(buf []byte) unsafe.Pointer {
+	base := uintptr(unsafe.Pointer(&buf[0]))
+	aligned := (base + 7) &^ uintptr(7)
+	return unsafe.Pointer(aligned + 1)
+}
+
+func BenchmarkClearFatLoweredZero56(b *testing.B) {
+	p := new([56]byte)
+	Escape(p)
+	b.SetBytes(56)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [56]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZero56Unaligned(b *testing.B) {
+	buf := make([]byte, 56+8)
+	p := (*[56]byte)(ptr8Unaligned(buf))
+	Escape(p)
+	b.SetBytes(56)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [56]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZero64(b *testing.B) {
+	p := new([64]byte)
+	Escape(p)
+	b.SetBytes(64)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [64]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZero64Unaligned(b *testing.B) {
+	buf := make([]byte, 64+8)
+	p := (*[64]byte)(ptr8Unaligned(buf))
+	Escape(p)
+	b.SetBytes(64)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [64]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZero127(b *testing.B) {
+	p := new([127]byte)
+	Escape(p)
+	b.SetBytes(127)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [127]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZero127Unaligned(b *testing.B) {
+	buf := make([]byte, 127+8)
+	p := (*[127]byte)(ptr8Unaligned(buf))
+	Escape(p)
+	b.SetBytes(127)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [127]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZero128(b *testing.B) {
+	p := new([128]byte)
+	Escape(p)
+	b.SetBytes(128)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [128]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZero128Unaligned(b *testing.B) {
+	buf := make([]byte, 128+8)
+	p := (*[128]byte)(ptr8Unaligned(buf))
+	Escape(p)
+	b.SetBytes(128)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [128]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZeroLoop248(b *testing.B) {
+	p := new([248]byte)
+	Escape(p)
+	b.SetBytes(248)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [248]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZeroLoop248Unaligned(b *testing.B) {
+	buf := make([]byte, 248+8)
+	p := (*[248]byte)(ptr8Unaligned(buf))
+	Escape(p)
+	b.SetBytes(248)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [248]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZeroLoop256(b *testing.B) {
+	p := new([256]byte)
+	Escape(p)
+	b.SetBytes(256)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [256]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZeroLoop256Unaligned(b *testing.B) {
+	buf := make([]byte, 256+8)
+	p := (*[256]byte)(ptr8Unaligned(buf))
+	Escape(p)
+	b.SetBytes(256)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [256]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZeroLoop320(b *testing.B) {
+	p := new([320]byte)
+	Escape(p)
+	b.SetBytes(320)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [320]byte{}
+	}
+}
+
+func BenchmarkClearFatLoweredZeroLoop320Unaligned(b *testing.B) {
+	buf := make([]byte, 320+8)
+	p := (*[320]byte)(ptr8Unaligned(buf))
+	Escape(p)
+	b.SetBytes(320)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		*p = [320]byte{}
+	}
+}
+
 func BenchmarkCopyFat7(b *testing.B) {
 	var x [7]byte
 	p := new([7]byte)

--- a/src/runtime/memmove_test.go
+++ b/src/runtime/memmove_test.go
@@ -1378,7 +1378,7 @@ func BenchmarkMemmoveKnownSize1024(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs8(b *testing.B) {
+func BenchmarkMemmoveKnownSize8(b *testing.B) {
 	type T struct {
 		x [8]int8
 	}
@@ -1393,7 +1393,7 @@ func BenchmarkMemmoveKnownSizeIs8(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs12(b *testing.B) {
+func BenchmarkMemmoveKnownSize12(b *testing.B) {
 	type T struct {
 		x [12]int8
 	}
@@ -1408,7 +1408,7 @@ func BenchmarkMemmoveKnownSizeIs12(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs14(b *testing.B) {
+func BenchmarkMemmoveKnownSize14(b *testing.B) {
 	type T struct {
 		x [14]int8
 	}
@@ -1423,7 +1423,7 @@ func BenchmarkMemmoveKnownSizeIs14(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs15(b *testing.B) {
+func BenchmarkMemmoveKnownSize15(b *testing.B) {
 	type T struct {
 		x [15]int8
 	}
@@ -1438,7 +1438,7 @@ func BenchmarkMemmoveKnownSizeIs15(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs16(b *testing.B) {
+func BenchmarkMemmoveKnownSize16(b *testing.B) {
 	type T struct {
 		x [16]int8
 	}
@@ -1453,7 +1453,7 @@ func BenchmarkMemmoveKnownSizeIs16(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs24(b *testing.B) {
+func BenchmarkMemmoveKnownSize24(b *testing.B) {
 	type T struct {
 		x [24]int8
 	}
@@ -1468,7 +1468,7 @@ func BenchmarkMemmoveKnownSizeIs24(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs56Loop(b *testing.B) {
+func BenchmarkMemmoveKnownSize56(b *testing.B) {
 	type T struct {
 		x [56]int8
 	}
@@ -1483,7 +1483,7 @@ func BenchmarkMemmoveKnownSizeIs56Loop(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs60Loop(b *testing.B) {
+func BenchmarkMemmoveKnownSize60(b *testing.B) {
 	type T struct {
 		x [60]int8
 	}
@@ -1498,7 +1498,7 @@ func BenchmarkMemmoveKnownSizeIs60Loop(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs62Loop(b *testing.B) {
+func BenchmarkMemmoveKnownSize62(b *testing.B) {
 	type T struct {
 		x [62]int8
 	}
@@ -1513,7 +1513,7 @@ func BenchmarkMemmoveKnownSizeIs62Loop(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs63Loop(b *testing.B) {
+func BenchmarkMemmoveKnownSize63(b *testing.B) {
 	type T struct {
 		x [63]int8
 	}
@@ -1528,7 +1528,7 @@ func BenchmarkMemmoveKnownSizeIs63Loop(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs64Loop(b *testing.B) {
+func BenchmarkMemmoveKnownSize64(b *testing.B) {
 	type T struct {
 		x [64]int8
 	}
@@ -1543,7 +1543,7 @@ func BenchmarkMemmoveKnownSizeIs64Loop(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs127Loop(b *testing.B) {
+func BenchmarkMemmoveKnownSize127(b *testing.B) {
 	type T struct {
 		x [127]int8
 	}
@@ -1558,7 +1558,7 @@ func BenchmarkMemmoveKnownSizeIs127Loop(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs128Loop(b *testing.B) {
+func BenchmarkMemmoveKnownSize128(b *testing.B) {
 	type T struct {
 		x [128]int8
 	}
@@ -1573,7 +1573,7 @@ func BenchmarkMemmoveKnownSizeIs128Loop(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs160Loop(b *testing.B) {
+func BenchmarkMemmoveKnownSize160(b *testing.B) {
 	type T struct {
 		x [160]int8
 	}
@@ -1588,7 +1588,7 @@ func BenchmarkMemmoveKnownSizeIs160Loop(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs164Loop(b *testing.B) {
+func BenchmarkMemmoveKnownSize164(b *testing.B) {
 	type T struct {
 		x [164]int8
 	}
@@ -1606,7 +1606,7 @@ func BenchmarkMemmoveKnownSizeIs164Loop(b *testing.B) {
 // Unaligned versions of the Loop benchmarks.
 // These use addresses that are 1-byte aligned but not 8-byte aligned.
 
-func BenchmarkMemmoveKnownSizeIs56LoopUnaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize56Unaligned(b *testing.B) {
 	type T struct {
 		x [56]int8
 	}
@@ -1626,7 +1626,7 @@ func BenchmarkMemmoveKnownSizeIs56LoopUnaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs60LoopUnaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize60Unaligned(b *testing.B) {
 	type T struct {
 		x [60]int8
 	}
@@ -1646,7 +1646,7 @@ func BenchmarkMemmoveKnownSizeIs60LoopUnaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs62LoopUnaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize62Unaligned(b *testing.B) {
 	type T struct {
 		x [62]int8
 	}
@@ -1666,7 +1666,7 @@ func BenchmarkMemmoveKnownSizeIs62LoopUnaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs63LoopUnaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize63Unaligned(b *testing.B) {
 	type T struct {
 		x [63]int8
 	}
@@ -1686,7 +1686,7 @@ func BenchmarkMemmoveKnownSizeIs63LoopUnaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs64LoopUnaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize64Unaligned(b *testing.B) {
 	type T struct {
 		x [64]int8
 	}
@@ -1706,7 +1706,7 @@ func BenchmarkMemmoveKnownSizeIs64LoopUnaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs127LoopUnaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize127Unaligned(b *testing.B) {
 	type T struct {
 		x [127]int8
 	}
@@ -1726,7 +1726,7 @@ func BenchmarkMemmoveKnownSizeIs127LoopUnaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs128LoopUnaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize128Unaligned(b *testing.B) {
 	type T struct {
 		x [128]int8
 	}
@@ -1746,7 +1746,7 @@ func BenchmarkMemmoveKnownSizeIs128LoopUnaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs160LoopUnaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize160Unaligned(b *testing.B) {
 	type T struct {
 		x [160]int8
 	}
@@ -1766,7 +1766,7 @@ func BenchmarkMemmoveKnownSizeIs160LoopUnaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs164LoopUnaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize164Unaligned(b *testing.B) {
 	type T struct {
 		x [164]int8
 	}
@@ -1786,7 +1786,7 @@ func BenchmarkMemmoveKnownSizeIs164LoopUnaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs8Unaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize8Unaligned(b *testing.B) {
 	type T struct {
 		x [8]int8
 	}
@@ -1806,7 +1806,7 @@ func BenchmarkMemmoveKnownSizeIs8Unaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs12Unaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize12Unaligned(b *testing.B) {
 	type T struct {
 		x [12]int8
 	}
@@ -1826,7 +1826,7 @@ func BenchmarkMemmoveKnownSizeIs12Unaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs14Unaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize14Unaligned(b *testing.B) {
 	type T struct {
 		x [14]int8
 	}
@@ -1846,7 +1846,7 @@ func BenchmarkMemmoveKnownSizeIs14Unaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs15Unaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize15Unaligned(b *testing.B) {
 	type T struct {
 		x [15]int8
 	}
@@ -1866,7 +1866,7 @@ func BenchmarkMemmoveKnownSizeIs15Unaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs16Unaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize16Unaligned(b *testing.B) {
 	type T struct {
 		x [16]int8
 	}
@@ -1886,7 +1886,7 @@ func BenchmarkMemmoveKnownSizeIs16Unaligned(b *testing.B) {
 	memclrSink = p.x[:]
 }
 
-func BenchmarkMemmoveKnownSizeIs24Unaligned(b *testing.B) {
+func BenchmarkMemmoveKnownSize24Unaligned(b *testing.B) {
 	type T struct {
 		x [24]int8
 	}


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
When we enable misaligned memory access, we can combine small size memroy access instrutions into big ones in `LoweredZero/LoweredMove/LoweredZeroLoop/LoweredMoveLoop`.

The performance results showed great improvment:
**move**
```
goos: linux
goarch: riscv64
pkg: runtime
                                 │ ssa_move_base.txt │          ssa_move_opt.txt           │
                                 │      sec/op       │    sec/op     vs base               │
MemmoveKnownSizeIs8-30                  4.652n ±  6%   4.593n ±  6%        ~ (p=0.589 n=6)
MemmoveKnownSizeIs12-30                 6.312n ±  3%   4.216n ±  3%  -33.22% (p=0.002 n=6)
MemmoveKnownSizeIs14-30                 7.213n ±  7%   4.381n ±  4%  -39.27% (p=0.002 n=6)
MemmoveKnownSizeIs15-30                 7.847n ±  4%   4.398n ±  3%  -43.95% (p=0.002 n=6)
MemmoveKnownSizeIs16-30                 8.006n ±  3%   3.966n ±  7%  -50.46% (p=0.002 n=6)
MemmoveKnownSizeIs24-30                11.670n ±  6%   4.385n ±  3%  -62.42% (p=0.002 n=6)
MemmoveKnownSizeIs8Unaligned-30         8.112n ±  2%   6.218n ±  7%  -23.34% (p=0.002 n=6)
MemmoveKnownSizeIs12Unaligned-30       11.215n ±  9%   6.386n ±  5%  -43.06% (p=0.002 n=6)
MemmoveKnownSizeIs14Unaligned-30        8.181n ± 10%   4.484n ± 14%  -45.19% (p=0.002 n=6)
MemmoveKnownSizeIs15Unaligned-30        8.374n ±  3%   3.949n ±  2%  -52.84% (p=0.002 n=6)
MemmoveKnownSizeIs16Unaligned-30        8.780n ±  3%   4.662n ±  8%  -46.91% (p=0.002 n=6)
MemmoveKnownSizeIs24Unaligned-30       12.640n ±  6%   4.490n ±  7%  -64.47% (p=0.002 n=6)
geomean                                 8.303n         4.624n        -44.31%

                                 │ ssa_move_base.txt │            ssa_move_opt.txt            │
                                 │        B/s        │      B/s        vs base                │
MemmoveKnownSizeIs8-30                  1.602Gi ± 6%    1.622Gi ±  5%         ~ (p=0.589 n=6)
MemmoveKnownSizeIs12-30                 1.771Gi ± 3%    2.651Gi ±  3%   +49.74% (p=0.002 n=6)
MemmoveKnownSizeIs14-30                 1.808Gi ± 6%    2.976Gi ±  4%   +64.58% (p=0.002 n=6)
MemmoveKnownSizeIs15-30                 1.780Gi ± 4%    3.177Gi ±  4%   +78.48% (p=0.002 n=6)
MemmoveKnownSizeIs16-30                 1.861Gi ± 3%    3.758Gi ±  8%  +101.87% (p=0.002 n=6)
MemmoveKnownSizeIs24-30                 1.915Gi ± 6%    5.098Gi ±  3%  +166.16% (p=0.002 n=6)
MemmoveKnownSizeIs8Unaligned-30         940.6Mi ± 2%   1227.1Mi ±  7%   +30.46% (p=0.002 n=6)
MemmoveKnownSizeIs12Unaligned-30       1020.6Mi ± 9%   1792.3Mi ±  5%   +75.61% (p=0.002 n=6)
MemmoveKnownSizeIs14Unaligned-30        1.595Gi ± 9%    2.908Gi ± 12%   +82.31% (p=0.002 n=6)
MemmoveKnownSizeIs15Unaligned-30        1.668Gi ± 3%    3.538Gi ±  2%  +112.08% (p=0.002 n=6)
MemmoveKnownSizeIs16Unaligned-30        1.697Gi ± 3%    3.197Gi ±  7%   +88.38% (p=0.002 n=6)
MemmoveKnownSizeIs24Unaligned-30        1.768Gi ± 6%    4.977Gi ±  6%  +181.57% (p=0.002 n=6)
geomean
```

**zero**
```
goos: linux
goarch: riscv64
pkg: runtime
                                       │ ssa_zero_base.txt │            ssa_zero_opt.txt             │
                                       │      sec/op       │    sec/op      vs base                  │
ClearFatLoweredZero56-30                    13.292n ±  88%   3.076n ±   6%        ~ (p=0.097 n=12+6)
ClearFatLoweredZero56Unaligned-30           19.850n ±  58%   8.474n ±  56%        ~ (p=0.097 n=12+6)
ClearFatLoweredZero64-30                    19.435n ±  66%   7.799n ±  54%        ~ (p=0.097 n=12+6)
ClearFatLoweredZero64Unaligned-30            20.30n ±  51%   10.61n ±  20%        ~ (p=0.097 n=12+6)
ClearFatLoweredZero127-30                    51.32n ±  65%   21.74n ± 104%        ~ (p=0.097 n=12+6)
ClearFatLoweredZero127Unaligned-30           38.30n ±  66%   14.52n ±  23%        ~ (p=0.097 n=12+6)
ClearFatLoweredZero128-30                   32.414n ± 170%   7.673n ±   8%        ~ (p=0.097 n=12+6)
ClearFatLoweredZero128Unaligned-30           37.36n ±  88%   13.45n ±  25%        ~ (p=0.097 n=12+6)
ClearFatLoweredZeroLoop248-30                76.17n ±  65%   28.07n ±  33%        ~ (p=0.095 n=12+6)
ClearFatLoweredZeroLoop248Unaligned-30       80.62n ±  51%   42.13n ±  28%        ~ (p=0.097 n=12+6)
ClearFatLoweredZeroLoop256-30                74.88n ±  67%   26.76n ±  25%        ~ (p=0.097 n=12+6)
ClearFatLoweredZeroLoop256Unaligned-30       91.45n ±  53%   44.85n ±  55%        ~ (p=0.097 n=12+6)
ClearFatLoweredZeroLoop320-30               104.83n ± 259%   41.78n ±  34%        ~ (p=0.097 n=12+6)
ClearFatLoweredZeroLoop320Unaligned-30      113.41n ± 173%   60.40n ±  15%        ~ (p=0.097 n=12+6)
geomean                                      44.62n          17.49n         -60.79%

                                       │ ssa_zero_base.txt │             ssa_zero_opt.txt              │
                                       │        B/s        │       B/s        vs base                  │
ClearFatLoweredZero56-30                    9.183Gi ±  87%   16.960Gi ±   7%        ~ (p=0.099 n=12+6)
ClearFatLoweredZero56Unaligned-30           2.962Gi ± 110%    6.155Gi ±  36%        ~ (p=0.099 n=12+6)
ClearFatLoweredZero64-30                    3.666Gi ± 150%    7.855Gi ± 113%        ~ (p=0.099 n=12+6)
ClearFatLoweredZero64Unaligned-30           3.415Gi ±  70%    5.625Gi ±  17%        ~ (p=0.099 n=12+6)
ClearFatLoweredZero127-30                   2.349Gi ± 179%    5.603Gi ± 188%        ~ (p=0.099 n=12+6)
ClearFatLoweredZero127Unaligned-30          4.535Gi ±  82%    8.150Gi ±  29%        ~ (p=0.099 n=12+6)
ClearFatLoweredZero128-30                   8.262Gi ±  91%   15.540Gi ±   7%        ~ (p=0.099 n=12+6)
ClearFatLoweredZero128Unaligned-30          4.587Gi ± 102%    8.884Gi ±  20%        ~ (p=0.099 n=12+6)
ClearFatLoweredZeroLoop248-30               4.090Gi ± 105%    8.230Gi ±  37%        ~ (p=0.099 n=12+6)
ClearFatLoweredZeroLoop248Unaligned-30      3.436Gi ±  63%    5.485Gi ±  39%        ~ (p=0.099 n=12+6)
ClearFatLoweredZeroLoop256-30               4.599Gi ± 108%    8.952Gi ±  21%        ~ (p=0.099 n=12+6)
ClearFatLoweredZeroLoop256Unaligned-30      2.765Gi ± 103%    5.330Gi ±  39%        ~ (p=0.099 n=12+6)
ClearFatLoweredZeroLoop320-30               3.628Gi ± 103%    7.140Gi ±  26%        ~ (p=0.099 n=12+6)
ClearFatLoweredZeroLoop320Unaligned-30      3.096Gi ±  69%    4.934Gi ±  13%        ~ (p=0.099 n=12+6)
geomean                                     4.008Gi           7.615Gi         +90.01%
```
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required