### PR TITLE
cmd/compile/internal/ssa: opt lowered zero/move clobbers to reduce spill

### DIFF
--- a/src/cmd/compile/internal/riscv64/ssa.go
+++ b/src/cmd/compile/internal/riscv64/ssa.go
@@ -864,7 +864,7 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		mov, sz := largestMove(sa.Off64())
 
 		var off int64
-		tmp := int16(riscv.REG_X5)
+		tmp := int16(riscv.REG_X25)
 		if buildcfg.GORISCV64EXT.MisalignedFast {
 			emitDynamicMoves(s, dst, src, tmp, off, n)
 		} else {
@@ -895,7 +895,7 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		sc := v.AuxValAndOff()
 		n := sc.Val64()
 		mov, sz := largestMove(sc.Off64())
-		tmp := int16(riscv.REG_X5)
+		tmp := int16(riscv.REG_X25)
 
 		if buildcfg.GORISCV64EXT.MisalignedFast {
 			//   n < 64:        fully unrolled with dynamic 8/4/2/1 moves
@@ -917,7 +917,7 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 			p.From.Offset = n - n%chunk
 			p.Reg = src
 			p.To.Type = obj.TYPE_REG
-			p.To.Reg = riscv.REG_X6
+			p.To.Reg = riscv.REG_X28
 
 			loopHead := s.Prog(obj.ANOP)
 			emitDynamicMoves(s, dst, src, tmp, 0, chunk)
@@ -935,7 +935,7 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 			p2.To.Reg = dst
 
 			p3 := s.Prog(riscv.ABNE)
-			p3.From.Reg = riscv.REG_X6
+			p3.From.Reg = riscv.REG_X28
 			p3.From.Type = obj.TYPE_REG
 			p3.Reg = src
 			p3.To.Type = obj.TYPE_BRANCH
@@ -958,7 +958,7 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		p.From.Offset = n - n%chunk
 		p.Reg = src
 		p.To.Type = obj.TYPE_REG
-		p.To.Reg = riscv.REG_X6
+		p.To.Reg = riscv.REG_X28
 
 		for i := int64(0); i < 8; i++ {
 			moveOp(s, mov, dst, src, tmp, sz*i)
@@ -977,7 +977,7 @@ func ssaGenValue(s *ssagen.State, v *ssa.Value) {
 		p2.To.Reg = dst
 
 		p3 := s.Prog(riscv.ABNE)
-		p3.From.Reg = riscv.REG_X6
+		p3.From.Reg = riscv.REG_X28
 		p3.From.Type = obj.TYPE_REG
 		p3.Reg = src
 		p3.To.Type = obj.TYPE_BRANCH

--- a/src/cmd/compile/internal/ssa/_gen/RISCV64Ops.go
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64Ops.go
@@ -319,8 +319,8 @@ func init() {
 			needIntTemp:    true,
 			faultOnNilArg0: true,
 			reg: regInfo{
-				inputs:   []regMask{regNamed["X5"]},
-				clobbers: regNamed["X5"],
+				inputs:   []regMask{regNamed["X25"]},
+				clobbers: regNamed["X25"],
 			},
 		},
 
@@ -338,8 +338,8 @@ func init() {
 			aux:       "SymValAndOff",
 			argLength: 3,
 			reg: regInfo{
-				inputs:   []regMask{regNamed["X6"], regNamed["X7"]},
-				clobbers: regNamed["X5"] | regNamed["X6"] | regNamed["X7"],
+				inputs:   []regMask{regNamed["X28"], regNamed["X29"]},
+				clobbers: regNamed["X25"] | regNamed["X28"] | regNamed["X29"],
 			},
 			typ:            "Mem",
 			symEffect:      "Write",
@@ -360,14 +360,14 @@ func init() {
 		//	...rest 7 mov...
 		//	ADD	$sz, Rarg0
 		//	ADD	$sz, Rarg1
-		//	BNE	X6, Rarg1, loop
+		//	BNE	X28, Rarg1, loop
 		{
 			name:      "LoweredMoveLoop",
 			aux:       "SymValAndOff",
 			argLength: 3,
 			reg: regInfo{
-				inputs:   []regMask{regNamed["X7"], regNamed["X8"]},
-				clobbers: regNamed["X5"] | regNamed["X6"] | regNamed["X7"] | regNamed["X8"],
+				inputs:   []regMask{regNamed["X29"], regNamed["X30"]},
+				clobbers: regNamed["X25"] | regNamed["X28"] | regNamed["X29"] | regNamed["X30"],
 			},
 			typ:            "Mem",
 			symEffect:      "Write",

--- a/src/cmd/compile/internal/ssa/opGen.go
+++ b/src/cmd/compile/internal/ssa/opGen.go
@@ -34563,9 +34563,9 @@ var opcodeTable = [...]opInfo{
 		symEffect:      SymWrite,
 		reg: regInfo{
 			inputs: []inputInfo{
-				{0, 16}, // X5
+				{0, 16777216}, // X25
 			},
-			clobbers: 16, // X5
+			clobbers: 16777216, // X25
 		},
 	},
 	{
@@ -34577,10 +34577,10 @@ var opcodeTable = [...]opInfo{
 		symEffect:      SymWrite,
 		reg: regInfo{
 			inputs: []inputInfo{
-				{0, 32}, // X6
-				{1, 64}, // X7
+				{0, 134217728}, // X28
+				{1, 268435456}, // X29
 			},
-			clobbers: 112, // X5 X6 X7
+			clobbers: 419430400, // X25 X28 X29
 		},
 	},
 	{
@@ -34592,10 +34592,10 @@ var opcodeTable = [...]opInfo{
 		symEffect:      SymWrite,
 		reg: regInfo{
 			inputs: []inputInfo{
-				{0, 64},  // X7
-				{1, 128}, // X8
+				{0, 268435456}, // X29
+				{1, 536870912}, // X30
 			},
-			clobbers: 240, // X5 X6 X7 X8
+			clobbers: 956301312, // X25 X28 X29 X30
 		},
 	},
 	{


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->
## Related Issue(s) & Descriptions
When generating code for `lowered zero/move` instructions, the register allocator frees registers declared in clobbers. If the current function needs to use the values stored in those registers and those values cannot be rematerialized, the allocator will generate spill and unspill code. 

Therefore,  Registers chosen to be clobbers should be used as infrequently as possible. A simple inspection of the runtime test assembly code (generated via `cd src/runtime && GOARCH=riscv64 GORISCV64=rva23 go test -c -o a.out`) shows that `X5, X7, X9, X11` are used far more frequently than `X25, X28, X29, X30`.

## Result
The number of lines in the runtime test assembly code is reduced by approximately 600.

**One specific example:**
before:
```
  message.go:1029 0x279ac8  96e8   MOV X5, 80(X2)              # spill
  message.go:1029 0x279aca  03010313  ADDI $48, X2, X6       
  message.go:1029 0x279ace  ba83   ADD X14, X0, X7        
  message.go:1029 0x279ad0  00038283  MOVB (X7), X5        
  message.go:1029 0x279ad4  00530023  MOVB X5, (X6)        
  message.go:1029 0x279ad8  00138283  MOVB 1(X7), X5        
  message.go:1029 0x279adc  005300a3  MOVB X5, 1(X6)        
  message.go:1029 0x279ae0  00238283  MOVB 2(X7), X5        
  message.go:1029 0x279ae4  00530123  MOVB X5, 2(X6)        
  message.go:1029 0x279ae8  00338283  MOVB 3(X7), X5        
  message.go:1029 0x279aec  005301a3  MOVB X5, 3(X6)        
  message.go:1029 0x279af0  00438283  MOVB 4(X7), X5        
  message.go:1029 0x279af4  00530223  MOVB X5, 4(X6)        
  message.go:1029 0x279af8  00538283  MOVB 5(X7), X5        
  message.go:1029 0x279afc  005302a3  MOVB X5, 5(X6)        
  message.go:1029 0x279b00  00638283  MOVB 6(X7), X5        
  message.go:1029 0x279b04  00530323  MOVB X5, 6(X6)        
  message.go:1029 0x279b08  00738283  MOVB 7(X7), X5        
  message.go:1029 0x279b0c  005303a3  MOVB X5, 7(X6)        
  message.go:1029 0x279b10  00838283  MOVB 8(X7), X5        
  message.go:1029 0x279b14  00530423  MOVB X5, 8(X6)        
  message.go:1029 0x279b18  00938283  MOVB 9(X7), X5        
  message.go:1029 0x279b1c  005304a3  MOVB X5, 9(X6)        
  message.go:1029 0x279b20  00a38283  MOVB 10(X7), X5        
  message.go:1029 0x279b24  00530523  MOVB X5, 10(X6)        
  message.go:1029 0x279b28  00b38283  MOVB 11(X7), X5        
  message.go:1029 0x279b2c  005305a3  MOVB X5, 11(X6)        
  message.go:1029 0x279b30  00c38283  MOVB 12(X7), X5        
  message.go:1029 0x279b34  00530623  MOVB X5, 12(X6)        
  message.go:1029 0x279b38  00d38283  MOVB 13(X7), X5        
  message.go:1029 0x279b3c  005306a3  MOVB X5, 13(X6)        
  message.go:1029 0x279b40  00e38283  MOVB 14(X7), X5        
  message.go:1029 0x279b44  00530723  MOVB X5, 14(X6)        
  message.go:1029 0x279b48  00f38283  MOVB 15(X7), X5        
  message.go:1029 0x279b4c  005307a3  MOVB X5, 15(X6)        
  message.go:1030 0x279b50  c662   MOV 80(X2), X5            # unspill
  message.go:1030 0x279b52  04028963  BEQZ X5, 20(PC) 
```
optimized:
```
  message.go:1029 0x279ad8  02010e93  ADDI $32, X2, X29       
  message.go:1029 0x279adc  8142   MOV X0, X5        
  message.go:1029 0x279ade  0143   MOV X0, X6        
  message.go:1029 0x279ae0  03010e13  ADDI $48, X2, X28       
  message.go:1029 0x279ae4  000e8f03  MOVB (X29), X30        
  message.go:1029 0x279ae8  01ee0023  MOVB X30, (X28)        
  message.go:1029 0x279aec  001e8f03  MOVB 1(X29), X30       
  message.go:1029 0x279af0  01ee00a3  MOVB X30, 1(X28)       
  message.go:1029 0x279af4  002e8f03  MOVB 2(X29), X30       
  message.go:1029 0x279af8  01ee0123  MOVB X30, 2(X28)       
  message.go:1029 0x279afc  003e8f03  MOVB 3(X29), X30       
  message.go:1029 0x279b00  01ee01a3  MOVB X30, 3(X28)       
  message.go:1029 0x279b04  004e8f03  MOVB 4(X29), X30       
  message.go:1029 0x279b08  01ee0223  MOVB X30, 4(X28)       
  message.go:1029 0x279b0c  005e8f03  MOVB 5(X29), X30       
  message.go:1029 0x279b10  01ee02a3  MOVB X30, 5(X28)       
  message.go:1029 0x279b14  006e8f03  MOVB 6(X29), X30       
  message.go:1029 0x279b18  01ee0323  MOVB X30, 6(X28)       
  message.go:1029 0x279b1c  007e8f03  MOVB 7(X29), X30       
  message.go:1029 0x279b20  01ee03a3  MOVB X30, 7(X28)       
  message.go:1029 0x279b24  008e8f03  MOVB 8(X29), X30       
  message.go:1029 0x279b28  01ee0423  MOVB X30, 8(X28)       
  message.go:1029 0x279b2c  009e8f03  MOVB 9(X29), X30       
  message.go:1029 0x279b30  01ee04a3  MOVB X30, 9(X28)       
  message.go:1029 0x279b34  00ae8f03  MOVB 10(X29), X30       
  message.go:1029 0x279b38  01ee0523  MOVB X30, 10(X28)       
  message.go:1029 0x279b3c  00be8f03  MOVB 11(X29), X30       
  message.go:1029 0x279b40  01ee05a3  MOVB X30, 11(X28)       
  message.go:1029 0x279b44  00ce8f03  MOVB 12(X29), X30       
  message.go:1029 0x279b48  01ee0623  MOVB X30, 12(X28)       
  message.go:1029 0x279b4c  00de8f03  MOVB 13(X29), X30       
  message.go:1029 0x279b50  01ee06a3  MOVB X30, 13(X28)       
  message.go:1029 0x279b54  00ee8f03  MOVB 14(X29), X30       
  message.go:1029 0x279b58  01ee0723  MOVB X30, 14(X28)       
  message.go:1029 0x279b5c  00fe8f03  MOVB 15(X29), X30       
  message.go:1029 0x279b60  01ee07a3  MOVB X30, 15(X28)       
  message.go:1030 0x279b64  04028863  BEQZ X5, 20(PC) 
```

The optimized version don't have spill/unspill code.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required