### PR TITLE
runtime: optimize memclrNoHeapPointers

### DIFF
--- a/src/runtime/memclr_riscv64.s
+++ b/src/runtime/memclr_riscv64.s
@@ -13,15 +13,18 @@ TEXT runtime·memclrNoHeapPointers<ABIInternal>(SB),NOSPLIT,$0-16
 	// X10 = ptr
 	// X11 = n
 
+#ifndef EnableSmallSizeMemVector
 	// If less than 8 bytes, do single byte zeroing.
 	MOV	$8, X9
 	BLT	X11, X9, check4
+#endif
 
 #ifndef hasV
 	MOVB	internal∕cpu·RISCV64+const_offsetRISCV64HasV(SB), X5
 	BEQZ	X5, memclr_scalar
 #endif
 
+#ifndef EnableSmallSizeMemVector
 	// Use vector if not 8 byte aligned.
 	AND	$7, X10, X5
 	BNEZ	X5, vector_start
@@ -29,11 +32,53 @@ TEXT runtime·memclrNoHeapPointers<ABIInternal>(SB),NOSPLIT,$0-16
 	// Use scalar if 8 byte aligned and <= 64 bytes.
 	SUB	$64, X11, X6
 	BLEZ	X6, aligned
+#endif
 
 	PCALIGN	$16
 vector_start:
 	VSETVLI	X0, E8, M8, TA, MA, X5
 	VMVVI	  $0, V8
+
+#ifdef EnableSmallSizeMemVector
+	PCALIGN	$16
+vector_dispatch:
+	MOV		$16, X6
+#ifdef VLen_256
+	SLLI	$1, X6
+#endif
+#ifdef VLen_512
+	SLLI	$2, X6
+#endif
+	BGEU	X6, X11, vector_single
+	SLLI	$2, X6
+	BGTU	X11, X6, vector_loop
+	SRLI	$1, X6
+	BGTU	X11, X6, vector_quarter
+
+// Zero (vlen+1)..(2*vlen) bytes
+	PCALIGN	$16
+vector_double:
+	VSETVLI	X11, E8, M2, TA, MA, X5
+	VSE8V	   V8, (X10)
+	RET
+
+// Zero 1..(vlen) bytes
+	PCALIGN	$16
+vector_single:
+	VSETVLI	X11, E8, M1, TA, MA, X5
+	VSE8V	   V8, (X10)
+	RET
+
+// Zero (2*vlen+1)..(4*vlen) bytes
+	PCALIGN	$16
+vector_quarter:
+	VSETVLI	X11, E8, M4, TA, MA, X5
+	VSE8V	   V8, (X10)
+	RET
+#endif
+
+// Zero (4*vlen+1).. bytes
+	PCALIGN	$16
 vector_loop:
 	VSETVLI	X11, E8, M8, TA, MA, X5
 	VSE8V	   V8, (X10) 
@@ -42,6 +87,7 @@ vector_loop:
 	BNEZ	X11, vector_loop
 	RET
 
+#ifndef hasV
 memclr_scalar:
 	// Check alignment
 	AND	$7, X10, X5
@@ -55,7 +101,9 @@ align:
 	MOVB	ZERO, 0(X10)
 	ADD	$1, X10
 	BNEZ	X5, align
+#endif
 
+#ifndef EnableSmallSizeMemVector
 aligned:
 	// X9 already contains $8
 	BLT	X11, X9, check4
@@ -129,6 +177,7 @@ loop1:
 	ADD	$1, X10
 	SUB	$1, X11
 	JMP	loop1
+#endif
 
 done:
 	RET


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions
Use the same method as https://github.com/zte-riscv/go/pull/116 to implement vectorization optimization for zeroing small size of memory. The macros used in this pr are same as those introduced in https://github.com/zte-riscv/go/pull/116.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Performance data
Tested on SG2044, taskset to an idle core:
```
goos: linux
goarch: riscv64
pkg: runtime
                        │  old_sg.txt   │             new_sg.txt              │
                        │    sec/op     │    sec/op     vs base               │
Memclr/5                   6.535n ±  0%   4.983n ±  1%  -23.75% (p=0.002 n=6)
Memclr/16                  7.706n ±  0%   4.954n ±  0%  -35.71% (p=0.002 n=6)
Memclr/64                  8.851n ±  0%   5.643n ±  1%  -36.24% (p=0.002 n=6)
Memclr/256                 13.15n ±  0%   13.15n ±  0%        ~ (p=0.307 n=6)
Memclr/4096                303.4n ± 12%   332.3n ± 16%   +9.52% (p=0.015 n=6)
Memclr/65536               13.93µ ±  8%   15.00µ ±  4%   +7.67% (p=0.009 n=6)
Memclr/1M                  331.7µ ±  2%   336.2µ ±  1%   +1.37% (p=0.026 n=6)
Memclr/4M                  1.480m ±  0%   1.489m ±  1%   +0.59% (p=0.002 n=6)
Memclr/8M                  2.971m ±  0%   2.986m ±  0%   +0.50% (p=0.026 n=6)                                                                                                                 
Memclr/16M                 5.960m ±  0%   5.952m ±  0%        ~ (p=0.818 n=6)                                                                                                                 
Memclr/64M                 23.92m ±  0%   23.97m ±  0%   +0.23% (p=0.002 n=6)                                                                                                                 
MemclrUnaligned/0_5        8.165n ±  1%   6.202n ±  0%  -24.05% (p=0.002 n=6)                                                                                                                 
MemclrUnaligned/0_16       9.210n ±  1%   6.199n ±  0%  -32.69% (p=0.002 n=6)                                                                                                                 
MemclrUnaligned/0_64      10.075n ±  0%   6.974n ±  0%  -30.78% (p=0.002 n=6)                                                                                                                 
MemclrUnaligned/0_256      13.90n ±  0%   13.91n ±  0%        ~ (p=0.206 n=6)                                                                                                                 
MemclrUnaligned/0_4096     343.6n ± 12%   404.1n ± 13%  +17.61% (p=0.015 n=6)                                                                                                                 
MemclrUnaligned/0_65536    13.76µ ± 15%   15.53µ ±  6%  +12.86% (p=0.026 n=6)                                                                                                                 
MemclrUnaligned/1_5        8.224n ±  2%   6.199n ±  0%  -24.62% (p=0.002 n=6)                                                                                                                 
MemclrUnaligned/1_16       6.907n ±  5%   6.196n ±  0%  -10.30% (p=0.002 n=6)                                                                                                                 
MemclrUnaligned/1_64       6.887n ±  0%   7.003n ±  0%   +1.68% (p=0.002 n=6)                                                                                                                 
MemclrUnaligned/1_256      20.95n ±  0%   22.27n ±  0%   +6.35% (p=0.002 n=6)                                                                                                                 
MemclrUnaligned/1_4096     485.8n ±  9%   649.6n ± 18%  +33.70% (p=0.002 n=6)
MemclrUnaligned/1_65536    14.72µ ± 11%   19.99µ ± 11%  +35.81% (p=0.002 n=6)
MemclrUnaligned/4_5        8.230n ±  7%   6.205n ±  0%  -24.60% (p=0.002 n=6)
MemclrUnaligned/4_16       6.909n ±  0%   6.210n ±  0%  -10.11% (p=0.002 n=6)
MemclrUnaligned/4_64       6.838n ±  1%   7.003n ±  0%   +2.41% (p=0.002 n=6)
MemclrUnaligned/4_256      20.08n ±  1%   20.16n ±  0%        ~ (p=0.056 n=6)
MemclrUnaligned/4_4096     512.0n ±  7%   605.6n ±  6%  +18.27% (p=0.002 n=6)
MemclrUnaligned/4_65536    16.13µ ±  4%   17.96µ ±  2%  +11.37% (p=0.002 n=6)
MemclrUnaligned/7_5        8.214n ±  1%   6.208n ±  0%  -24.43% (p=0.002 n=6)
MemclrUnaligned/7_16       6.921n ±  3%   6.199n ±  0%  -10.43% (p=0.002 n=6)
MemclrUnaligned/7_64       6.906n ±  1%   7.006n ±  0%   +1.45% (p=0.002 n=6)
MemclrUnaligned/7_256      20.95n ±  0%   22.33n ±  1%   +6.61% (p=0.002 n=6)
MemclrUnaligned/7_4096     479.7n ± 13%   583.8n ± 26%  +21.69% (p=0.002 n=6)
MemclrUnaligned/7_65536    15.45µ ± 11%   17.06µ ±  7%  +10.41% (p=0.026 n=6)
MemclrUnaligned/0_1M       330.1µ ±  1%   337.3µ ±  1%   +2.20% (p=0.002 n=6)
MemclrUnaligned/0_4M       1.477m ±  3%   1.488m ±  0%        ~ (p=0.065 n=6)
MemclrUnaligned/0_8M       2.972m ±  0%   2.994m ±  0%   +0.74% (p=0.004 n=6)
MemclrUnaligned/0_16M      5.966m ±  0%   5.992m ±  0%   +0.43% (p=0.002 n=6)
MemclrUnaligned/0_64M      23.79m ±  0%   23.99m ±  1%   +0.85% (p=0.002 n=6)
MemclrUnaligned/1_1M       345.1µ ±  2%   348.4µ ±  0%   +0.98% (p=0.002 n=6)
MemclrUnaligned/1_4M       1.480m ±  0%   1.494m ±  0%   +0.91% (p=0.002 n=6)
MemclrUnaligned/1_8M       2.975m ±  1%   2.978m ±  0%        ~ (p=0.485 n=6)
MemclrUnaligned/1_16M      5.969m ±  2%   5.980m ±  0%        ~ (p=0.065 n=6)
MemclrUnaligned/1_64M      23.93m ±  0%   23.96m ±  0%        ~ (p=0.065 n=6)
MemclrUnaligned/4_1M       345.7µ ±  5%   347.9µ ±  1%        ~ (p=0.240 n=6)
MemclrUnaligned/4_4M       1.485m ±  2%   1.488m ±  0%        ~ (p=0.310 n=6)
MemclrUnaligned/4_8M       2.970m ±  0%   2.983m ±  0%   +0.43% (p=0.009 n=6)
MemclrUnaligned/4_16M      5.960m ±  0%   5.981m ±  0%   +0.36% (p=0.002 n=6)
MemclrUnaligned/4_64M      23.93m ±  0%   23.95m ±  0%        ~ (p=0.589 n=6)
MemclrUnaligned/7_1M       343.9µ ±  0%   348.0µ ±  1%   +1.19% (p=0.004 n=6)
MemclrUnaligned/7_4M       1.563m ±  5%   1.486m ±  0%   -4.92% (p=0.004 n=6)
MemclrUnaligned/7_8M       3.104m ±  2%   2.980m ±  0%   -4.01% (p=0.002 n=6)
MemclrUnaligned/7_16M      6.246m ±  1%   5.948m ±  0%   -4.77% (p=0.002 n=6)
MemclrUnaligned/7_64M      24.53m ±  3%   23.96m ±  1%        ~ (p=0.394 n=6)
MemclrRange/1K_2K          6.917µ ± 12%   7.559µ ± 12%   +9.28% (p=0.009 n=6)
MemclrRange/2K_8K          30.80µ ± 14%   35.27µ ± 11%  +14.51% (p=0.009 n=6)
MemclrRange/4K_16K         36.59µ ± 43%   50.77µ ± 15%  +38.75% (p=0.026 n=6)
MemclrRange/160K_228K      463.7µ ±  4%   483.6µ ±  4%   +4.29% (p=0.026 n=6)
MemclrKnownSize1           6.513n ±  0%   4.697n ±  1%  -27.89% (p=0.002 n=6)
MemclrKnownSize2           7.163n ±  1%   4.268n ±  1%  -40.42% (p=0.002 n=6)
MemclrKnownSize4           5.568n ±  1%   4.720n ±  2%  -15.24% (p=0.002 n=6)
MemclrKnownSize8           6.721n ±  1%   4.310n ±  1%  -35.87% (p=0.002 n=6)
MemclrKnownSize16          7.466n ±  0%   4.801n ±  1%  -35.69% (p=0.002 n=6)
MemclrKnownSize32          7.790n ±  0%   5.277n ±  1%  -32.26% (p=0.002 n=6)
MemclrKnownSize64          8.316n ±  0%   5.151n ±  1%  -38.05% (p=0.002 n=6)
MemclrKnownSize112         5.919n ±  0%   5.551n ±  0%   -6.23% (p=0.002 n=6)
MemclrKnownSize128         6.047n ±  0%   5.770n ±  1%   -4.58% (p=0.002 n=6)
MemclrKnownSize192         20.85n ±  0%   20.52n ±  0%   -1.56% (p=0.002 n=6)
MemclrKnownSize248         21.61n ±  0%   20.89n ±  2%   -3.33% (p=0.002 n=6)
MemclrKnownSize256         13.13n ±  0%   13.15n ±  3%   +0.11% (p=0.045 n=6)
MemclrKnownSize512         25.75n ±  1%   26.66n ±  3%   +3.55% (p=0.015 n=6)
MemclrKnownSize1024        63.36n ± 13%   58.37n ±  7%        ~ (p=0.132 n=6)
MemclrKnownSize4096        299.1n ± 18%   314.5n ± 14%        ~ (p=0.394 n=6)
MemclrKnownSize512KiB      157.7µ ±  2%   160.9µ ±  5%   +2.01% (p=0.015 n=6)
geomean                    2.579µ         2.448µ         -5.09%

                        │   old_sg.txt   │              new_sg.txt               │
                        │      B/s       │      B/s        vs base               │
Memclr/5                   729.7Mi ±  0%    957.0Mi ±  1%  +31.16% (p=0.002 n=6)
Memclr/16                  1.934Gi ±  0%    3.008Gi ±  0%  +55.55% (p=0.002 n=6)
Memclr/64                  6.734Gi ±  0%   10.562Gi ±  1%  +56.83% (p=0.002 n=6)
Memclr/256                 18.14Gi ±  0%    18.13Gi ±  0%        ~ (p=0.310 n=6)
Memclr/4096                12.57Gi ± 14%    11.48Gi ± 14%   -8.66% (p=0.015 n=6)
Memclr/65536               4.382Gi ±  9%    4.072Gi ±  4%   -7.08% (p=0.009 n=6)
Memclr/1M                  2.944Gi ±  2%    2.905Gi ±  1%   -1.35% (p=0.026 n=6)
Memclr/4M                  2.639Gi ±  0%    2.624Gi ±  1%   -0.58% (p=0.002 n=6)
Memclr/8M                  2.629Gi ±  0%    2.616Gi ±  0%   -0.49% (p=0.026 n=6)
Memclr/16M                 2.622Gi ±  0%    2.625Gi ±  0%        ~ (p=0.818 n=6)
Memclr/64M                 2.613Gi ±  0%    2.607Gi ±  0%   -0.22% (p=0.002 n=6)
MemclrUnaligned/0_5        584.0Mi ±  1%    768.9Mi ±  0%  +31.66% (p=0.002 n=6)
MemclrUnaligned/0_16       1.618Gi ±  1%    2.404Gi ±  0%  +48.56% (p=0.002 n=6)
MemclrUnaligned/0_64       5.916Gi ±  0%    8.547Gi ±  0%  +44.48% (p=0.002 n=6)
MemclrUnaligned/0_256      17.16Gi ±  0%    17.14Gi ±  0%        ~ (p=0.180 n=6)
MemclrUnaligned/0_4096    11.116Gi ± 11%    9.439Gi ± 16%  -15.09% (p=0.015 n=6)
MemclrUnaligned/0_65536    4.436Gi ± 13%    3.932Gi ±  6%  -11.38% (p=0.026 n=6)
MemclrUnaligned/1_5        579.8Mi ±  2%    769.1Mi ±  0%  +32.66% (p=0.002 n=6)
MemclrUnaligned/1_16       2.157Gi ±  5%    2.405Gi ±  0%  +11.49% (p=0.002 n=6)
MemclrUnaligned/1_64       8.655Gi ±  0%    8.511Gi ±  0%   -1.66% (p=0.002 n=6)
MemclrUnaligned/1_256      11.38Gi ±  0%    10.70Gi ±  0%   -5.97% (p=0.002 n=6)
MemclrUnaligned/1_4096     7.852Gi ±  8%    5.880Gi ± 22%  -25.12% (p=0.002 n=6)
MemclrUnaligned/1_65536    4.147Gi ± 10%    3.053Gi ± 12%  -26.37% (p=0.002 n=6)
MemclrUnaligned/4_5        579.4Mi ±  6%    768.4Mi ±  0%  +32.63% (p=0.002 n=6)
MemclrUnaligned/4_16       2.157Gi ±  0%    2.400Gi ±  0%  +11.25% (p=0.002 n=6)
MemclrUnaligned/4_64       8.717Gi ±  1%    8.512Gi ±  0%   -2.35% (p=0.002 n=6)
MemclrUnaligned/4_256      11.87Gi ±  1%    11.83Gi ±  0%   -0.40% (p=0.041 n=6)
MemclrUnaligned/4_4096     7.452Gi ±  6%    6.301Gi ±  7%  -15.45% (p=0.002 n=6)
MemclrUnaligned/4_65536    3.784Gi ±  4%    3.398Gi ±  2%  -10.20% (p=0.002 n=6)
MemclrUnaligned/7_5        580.5Mi ±  1%    768.1Mi ±  0%  +32.32% (p=0.002 n=6)
MemclrUnaligned/7_16       2.153Gi ±  3%    2.404Gi ±  0%  +11.65% (p=0.002 n=6)
MemclrUnaligned/7_64       8.631Gi ±  1%    8.508Gi ±  0%   -1.42% (p=0.002 n=6)
MemclrUnaligned/7_256      11.38Gi ±  0%    10.68Gi ±  1%   -6.21% (p=0.002 n=6)
MemclrUnaligned/7_4096     7.953Gi ± 15%    6.540Gi ± 21%  -17.77% (p=0.002 n=6)
MemclrUnaligned/7_65536    3.949Gi ± 10%    3.577Gi ±  6%   -9.43% (p=0.026 n=6)
MemclrUnaligned/0_1M       2.958Gi ±  1%    2.895Gi ±  1%   -2.15% (p=0.002 n=6)
MemclrUnaligned/0_4M       2.645Gi ±  3%    2.625Gi ±  0%        ~ (p=0.065 n=6)
MemclrUnaligned/0_8M       2.628Gi ±  0%    2.609Gi ±  0%   -0.74% (p=0.004 n=6)
MemclrUnaligned/0_16M      2.619Gi ±  0%    2.608Gi ±  0%   -0.42% (p=0.002 n=6)
MemclrUnaligned/0_64M      2.627Gi ±  0%    2.605Gi ±  1%   -0.84% (p=0.002 n=6)
MemclrUnaligned/1_1M       2.830Gi ±  2%    2.803Gi ±  0%   -0.97% (p=0.002 n=6)
MemclrUnaligned/1_4M       2.639Gi ±  0%    2.615Gi ±  0%   -0.90% (p=0.002 n=6)
MemclrUnaligned/1_8M       2.626Gi ±  1%    2.623Gi ±  0%        ~ (p=0.485 n=6)
MemclrUnaligned/1_16M      2.618Gi ±  2%    2.613Gi ±  0%        ~ (p=0.065 n=6)
MemclrUnaligned/1_64M      2.612Gi ±  0%    2.608Gi ±  0%        ~ (p=0.065 n=6)
MemclrUnaligned/4_1M       2.825Gi ±  5%    2.807Gi ±  1%        ~ (p=0.240 n=6)
MemclrUnaligned/4_4M       2.630Gi ±  2%    2.625Gi ±  0%        ~ (p=0.310 n=6)
MemclrUnaligned/4_8M       2.631Gi ±  0%    2.619Gi ±  0%   -0.43% (p=0.009 n=6)
MemclrUnaligned/4_16M      2.622Gi ±  0%    2.613Gi ±  0%   -0.35% (p=0.002 n=6)
MemclrUnaligned/4_64M      2.611Gi ±  0%    2.609Gi ±  0%        ~ (p=0.589 n=6)
MemclrUnaligned/7_1M       2.839Gi ±  0%    2.806Gi ±  1%   -1.18% (p=0.004 n=6)
MemclrUnaligned/7_4M       2.499Gi ±  5%    2.628Gi ±  0%   +5.17% (p=0.004 n=6)
MemclrUnaligned/7_8M       2.517Gi ±  2%    2.622Gi ±  0%   +4.18% (p=0.002 n=6)
MemclrUnaligned/7_16M      2.501Gi ±  1%    2.627Gi ±  0%   +5.01% (p=0.002 n=6)
MemclrUnaligned/7_64M      2.548Gi ±  3%    2.609Gi ±  1%        ~ (p=0.394 n=6)
MemclrRange/1K_2K          12.91Gi ± 13%    11.81Gi ± 11%   -8.50% (p=0.009 n=6)
MemclrRange/2K_8K         10.085Gi ± 16%    8.806Gi ± 10%  -12.68% (p=0.009 n=6)
MemclrRange/4K_16K         8.244Gi ± 30%    5.927Gi ± 17%  -28.10% (p=0.026 n=6)
MemclrRange/160K_228K      3.340Gi ±  5%    3.202Gi ±  4%   -4.12% (p=0.026 n=6)
MemclrKnownSize1           146.4Mi ±  0%    203.1Mi ±  1%  +38.68% (p=0.002 n=6)
MemclrKnownSize2           266.3Mi ±  1%    446.9Mi ±  1%  +67.84% (p=0.002 n=6)
MemclrKnownSize4           685.1Mi ±  1%    808.3Mi ±  2%  +17.99% (p=0.002 n=6)
MemclrKnownSize8           1.109Gi ±  1%    1.729Gi ±  1%  +55.95% (p=0.002 n=6)
MemclrKnownSize16          1.996Gi ±  0%    3.103Gi ±  1%  +55.50% (p=0.002 n=6)
MemclrKnownSize32          3.826Gi ±  0%    5.648Gi ±  1%  +47.62% (p=0.002 n=6)
MemclrKnownSize64          7.168Gi ±  0%   11.570Gi ±  1%  +61.42% (p=0.002 n=6)
MemclrKnownSize112         17.62Gi ±  0%    18.79Gi ±  0%   +6.65% (p=0.002 n=6)
MemclrKnownSize128         19.71Gi ±  0%    20.66Gi ±  1%   +4.81% (p=0.002 n=6)
MemclrKnownSize192         8.576Gi ±  0%    8.713Gi ±  0%   +1.60% (p=0.002 n=6)
MemclrKnownSize248         10.69Gi ±  0%    11.05Gi ±  2%   +3.44% (p=0.002 n=6)
MemclrKnownSize256         18.16Gi ±  0%    18.14Gi ±  3%        ~ (p=0.093 n=6)
MemclrKnownSize512         18.52Gi ±  1%    17.89Gi ±  4%   -3.43% (p=0.015 n=6)
MemclrKnownSize1024        15.06Gi ± 12%    16.34Gi ±  7%        ~ (p=0.132 n=6)
MemclrKnownSize4096        12.78Gi ± 15%    12.13Gi ± 13%        ~ (p=0.394 n=6)
MemclrKnownSize512KiB      3.096Gi ±  2%    3.035Gi ±  5%   -1.97% (p=0.015 n=6)
geomean                    3.687Gi          3.884Gi         +5.36%

```

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required