### PR TITLE
internal/bytealg: vector implementation of count 1 byte for riscv64

### DIFF
--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -4008,21 +4008,6 @@ func (ins *instruction) compress() {
 			ins.as = ACLD
 		}
 
-	case ALH:
-		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && isScaledImmU(ins.imm, 2, 2) {
-			ins.as = ACLH
-		}
-
-	case ALBU:
-		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && immUFits(ins.imm, 2) == nil{
-			ins.as = ACLBU
-		}
-
-	case ALHU:
-		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && isScaledImmU(ins.imm, 2, 2) {
-			ins.as = ACLHU
-		}
-
 	case AFLD:
 		if ins.rs1 == REG_SP && isScaledImmU(ins.imm, 9, 8) {
 			ins.as, ins.rs1, ins.rs2 = ACFLDSP, obj.REG_NONE, ins.rs1
@@ -4042,16 +4027,6 @@ func (ins *instruction) compress() {
 			ins.as, ins.rs1, ins.rs2 = ACSDSP, obj.REG_NONE, ins.rs1
 		} else if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && isScaledImmU(ins.imm, 8, 8) {
 			ins.as, ins.rd, ins.rs1, ins.rs2 = ACSD, obj.REG_NONE, ins.rd, ins.rs1
-		}
-
-	case ASB:
-		if isIntPrimeReg(ins.rs1) && isIntPrimeReg(ins.rs2) && immUFits(ins.imm, 2) == nil {
-			ins.as, ins.rd, ins.rs1, ins.rs2 = ACSB, obj.REG_NONE, ins.rd, ins.rs1
-		}
-
-	case ASH:
-		if isIntPrimeReg(ins.rs1) && isIntPrimeReg(ins.rs2) && isScaledImmU(ins.imm, 2, 2) {
-			ins.as, ins.rd, ins.rs1, ins.rs2 = ACSH, obj.REG_NONE, ins.rd, ins.rs1
 		}
 
 	case AFSD:
@@ -4104,28 +4079,6 @@ func (ins *instruction) compress() {
 	case AANDI:
 		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && immIFits(ins.imm, 6) == nil {
 			ins.as = ACANDI
-		} else if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1  && ins.imm == 0xff {
-			ins.as = ACZEXTB
-		}
-
-	case ASEXTB:
-		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 {
-			ins.as = ACSEXTB
-		}
-
-	case ASEXTH:
-		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 {
-			ins.as = ACSEXTH
-		}
-
-	case AZEXTH:
-		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 {
-			ins.as = ACZEXTH
-		}
-
-	case AADDUW:
-		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && ins.rs2 == REG_X0 {
-			ins.as, ins.rs2 = ACZEXTW, obj.REG_NONE
 		}
 
 	case AADD:
@@ -4135,11 +4088,6 @@ func (ins *instruction) compress() {
 			ins.as, ins.rs1, ins.rs2 = ACADD, ins.rs2, ins.rs1
 		} else if ins.rd != REG_X0 && ins.rs1 == REG_X0 && ins.rs2 != REG_X0 {
 			ins.as = ACMV
-		}
-
-	case AMUL:
-		if ins.rd == ins.rs1 && isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs2) {
-			ins.as = ACMUL
 		}
 
 	case AADDW:
@@ -4178,11 +4126,6 @@ func (ins *instruction) compress() {
 			ins.as = ACXOR
 		} else if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && ins.rd == ins.rs2 {
 			ins.as, ins.rs1, ins.rs2 = ACXOR, ins.rs2, ins.rs1
-		}
-
-	case AXORI:
-		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && ins.imm == -1 {
-			ins.as = ACNOT
 		}
 
 	case AEBREAK:

--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -4008,6 +4008,21 @@ func (ins *instruction) compress() {
 			ins.as = ACLD
 		}
 
+	case ALH:
+		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && isScaledImmU(ins.imm, 2, 2) {
+			ins.as = ACLH
+		}
+
+	case ALBU:
+		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && immUFits(ins.imm, 2) == nil{
+			ins.as = ACLBU
+		}
+
+	case ALHU:
+		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && isScaledImmU(ins.imm, 2, 2) {
+			ins.as = ACLHU
+		}
+
 	case AFLD:
 		if ins.rs1 == REG_SP && isScaledImmU(ins.imm, 9, 8) {
 			ins.as, ins.rs1, ins.rs2 = ACFLDSP, obj.REG_NONE, ins.rs1
@@ -4027,6 +4042,16 @@ func (ins *instruction) compress() {
 			ins.as, ins.rs1, ins.rs2 = ACSDSP, obj.REG_NONE, ins.rs1
 		} else if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && isScaledImmU(ins.imm, 8, 8) {
 			ins.as, ins.rd, ins.rs1, ins.rs2 = ACSD, obj.REG_NONE, ins.rd, ins.rs1
+		}
+
+	case ASB:
+		if isIntPrimeReg(ins.rs1) && isIntPrimeReg(ins.rs2) && immUFits(ins.imm, 2) == nil {
+			ins.as, ins.rd, ins.rs1, ins.rs2 = ACSB, obj.REG_NONE, ins.rd, ins.rs1
+		}
+
+	case ASH:
+		if isIntPrimeReg(ins.rs1) && isIntPrimeReg(ins.rs2) && isScaledImmU(ins.imm, 2, 2) {
+			ins.as, ins.rd, ins.rs1, ins.rs2 = ACSH, obj.REG_NONE, ins.rd, ins.rs1
 		}
 
 	case AFSD:
@@ -4079,6 +4104,28 @@ func (ins *instruction) compress() {
 	case AANDI:
 		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && immIFits(ins.imm, 6) == nil {
 			ins.as = ACANDI
+		} else if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1  && ins.imm == 0xff {
+			ins.as = ACZEXTB
+		}
+
+	case ASEXTB:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 {
+			ins.as = ACSEXTB
+		}
+
+	case ASEXTH:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 {
+			ins.as = ACSEXTH
+		}
+
+	case AZEXTH:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 {
+			ins.as = ACZEXTH
+		}
+
+	case AADDUW:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && ins.rs2 == REG_X0 {
+			ins.as, ins.rs2 = ACZEXTW, obj.REG_NONE
 		}
 
 	case AADD:
@@ -4088,6 +4135,11 @@ func (ins *instruction) compress() {
 			ins.as, ins.rs1, ins.rs2 = ACADD, ins.rs2, ins.rs1
 		} else if ins.rd != REG_X0 && ins.rs1 == REG_X0 && ins.rs2 != REG_X0 {
 			ins.as = ACMV
+		}
+
+	case AMUL:
+		if ins.rd == ins.rs1 && isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs2) {
+			ins.as = ACMUL
 		}
 
 	case AADDW:
@@ -4126,6 +4178,11 @@ func (ins *instruction) compress() {
 			ins.as = ACXOR
 		} else if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && ins.rd == ins.rs2 {
 			ins.as, ins.rs1, ins.rs2 = ACXOR, ins.rs2, ins.rs1
+		}
+
+	case AXORI:
+		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && ins.imm == -1 {
+			ins.as = ACNOT
 		}
 
 	case AEBREAK:

--- a/src/internal/bytealg/count_riscv64.s
+++ b/src/internal/bytealg/count_riscv64.s
@@ -2,34 +2,54 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+#include "asm_riscv64.h"
 #include "go_asm.h"
 #include "textflag.h"
 
-TEXT ·CountString<ABIInternal>(SB),NOSPLIT,$0-32
+TEXT ·CountString<ABIInternal>(SB),NOSPLIT|NOFRAME,$0
 	// X10 = s_base
 	// X11 = s_len
 	// X12 = byte to count
-	MOV	X12, X13
+	MOV	X12, X13 // byte to Count wanted in X13
 	JMP	·Count<ABIInternal>(SB)
 
-TEXT ·Count<ABIInternal>(SB),NOSPLIT,$0-40
+TEXT ·Count<ABIInternal>(SB),NOSPLIT|NOFRAME,$0
 	// X10 = b_base
 	// X11 = b_len
 	// X12 = b_cap (unused)
-	// X13 = byte to count (want in X12)
-	AND	$0xff, X13, X12
-	MOV	ZERO, X14	// count
-	ADD	X10, X11	// end
+	// X13 = byte to count
+	MOV	X10, X14	// src pointer
+	MOV	ZERO, X10	// reset counter
+	AND	$0xff, X13	// make sure it's a byte to compare
+	SUB	$8, X11, X5
+	BLEZ	X5, count_scalar
+#ifndef hasV
+	MOVB	internal∕cpu·RISCV64+const_offsetRISCV64HasV(SB), X5
+	BEQZ	X5, count_scalar
+#endif
+	PCALIGN	$16
+count_vector_loop:
+	VSETVLI	X11, E8, M8, TA, MA, X5
+	VLE8V	(X14), V8
+	VMSEQVX	X13, V8, V0
+	VCPOPM	V0, X15
+	ADD	X15, X10	// add counter
+	ADD	X5, X14
+	SUB	X5, X11
+	BEQZ	X11, done
+	JMP	count_vector_loop
 
 	PCALIGN	$16
-loop:
-	BEQ	X10, X11, done
-	MOVBU	(X10), X15
-	ADD	$1, X10
-	BNE	X12, X15, loop
+count_scalar:
+	ADD	X14, X11	// end pointer
+	PCALIGN	$16
+count_scalar_loop:
+	BEQ	X14, X11, done
+	MOVBU	(X14), X15
 	ADD	$1, X14
-	JMP	loop
+	BNE	X13, X15, count_scalar_loop
+	ADD	$1, X10
+	JMP	count_scalar_loop
 
 done:
-	MOV	X14, X10
 	RET

--- a/src/internal/bytealg/count_riscv64.s
+++ b/src/internal/bytealg/count_riscv64.s
@@ -31,8 +31,8 @@ TEXT ·Count<ABIInternal>(SB),NOSPLIT|NOFRAME,$0
 count_vector_loop:
 	VSETVLI	X11, E8, M8, TA, MA, X5
 	VLE8V	(X14), V8
-	VMSEQVX	X13, V8, V0
-	VCPOPM	V0, X15
+	VMSEQVX	X13, V8, V1
+	VCPOPM	V1, X15
 	ADD	X15, X10	// add counter
 	ADD	X5, X14
 	SUB	X5, X11


### PR DESCRIPTION
https://go-review.googlesource.com/c/go/+/657036
This CL provide a vector implementation of count 1 byte
```
goos: linux
goarch: riscv64
pkg: bytes
cpu: Spacemit(R) X60
                │         sec/op         │   sec/op     vs base                │
CountSingle/10               42.12n ± 0%   44.49n ± 0%   +5.64% (p=0.000 n=10)
CountSingle/32               85.74n ± 0%   44.49n ± 0%  -48.11% (p=0.000 n=10)
CountSingle/4K              8371.5n ± 0%   396.7n ± 0%  -95.26% (p=0.000 n=10)
CountSingle/4M              8929.1µ ± 0%   756.9µ ± 0%  -91.52% (p=0.000 n=10)
CountSingle/64M             159.78m ± 0%   13.89m ± 0%  -91.30% (p=0.000 n=10)
geomean                      33.65µ        6.073µ       -81.95%

                │ /root/scalar_count.log │         /root/vector_count.log          │
                │          B/s           │      B/s       vs base                  │
CountSingle/10              226.4Mi ± 0%    214.3Mi ± 0%     -5.34% (p=0.000 n=10)
CountSingle/32              355.9Mi ± 0%    685.9Mi ± 0%    +92.71% (p=0.000 n=10)
CountSingle/4K              466.6Mi ± 0%   9846.5Mi ± 0%  +2010.19% (p=0.000 n=10)
CountSingle/4M              448.0Mi ± 0%   5284.9Mi ± 0%  +1079.74% (p=0.000 n=10)
CountSingle/64M             400.5Mi ± 0%   4606.2Mi ± 0%  +1049.98% (p=0.000 n=10)
geomean                     368.0Mi         1.991Gi        +454.08%
```
Change-Id: [If88361e8fc2293fc73d4aa5d95903770516918f4](https://go-review.googlesource.com/q/If88361e8fc2293fc73d4aa5d95903770516918f4)