### PR TITLE
crypto/internal/poly1305: provide optimised assembly for riscv64

### DIFF
--- a/src/vendor/golang.org/x/crypto/internal/poly1305/mac_noasm.go
+++ b/src/vendor/golang.org/x/crypto/internal/poly1305/mac_noasm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (!amd64 && !loong64 && !ppc64le && !ppc64 && !s390x) || !gc || purego
+//go:build (!amd64 && !loong64 && !ppc64le && !ppc64 && !s390x && !riscv64) || !gc || purego
 
 package poly1305
 

--- a/src/vendor/golang.org/x/crypto/internal/poly1305/sum_asm.go
+++ b/src/vendor/golang.org/x/crypto/internal/poly1305/sum_asm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build gc && !purego && (amd64 || loong64 || ppc64 || ppc64le)
+//go:build gc && !purego && (amd64 || loong64 || ppc64 || ppc64le || riscv64)
 
 package poly1305
 

--- a/src/vendor/golang.org/x/crypto/internal/poly1305/sum_riscv64.s
+++ b/src/vendor/golang.org/x/crypto/internal/poly1305/sum_riscv64.s
@@ -1,0 +1,215 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build gc && !purego && riscv64
+
+#include "textflag.h"
+
+// func update(state *macState, msg []byte)
+TEXT ·update(SB),NOSPLIT,$0-32
+	MOV	state+0(FP), X10	// state pointer
+	MOV	msg_base+8(FP), X11	// msg base
+	MOV	msg_len+16(FP), X12	// msg length
+
+	MOV	$16, X13		// TagSize = 16
+
+	// Load state: h0, h1, h2, r0, r1
+	MOV	(X10), X5		// h0
+	MOV	8(X10), X6		// h1
+	MOV	16(X10), X7		// h2
+	MOV	24(X10), X8		// r0
+	MOV	32(X10), X9		// r1
+
+	// Check if msg length >= 16
+	BLTU	X12, X13, bytes_between_0_and_15
+
+loop:
+	// Load 16 bytes from msg
+	MOV	(X11), X14		// msg[0:8]
+	MOV	8(X11), X15		// msg[8:16]
+
+	// h0 += msg[0:8]
+	ADD	X14, X5, X5		// h0 = h0 + msg[0:8]
+	SLTU	X14, X5, X16		// carry from h0
+
+	// h1 += msg[8:16] + carry
+	ADD	X15, X6, X17		// h1 + msg[8:16]
+	SLTU	X15, X17, X18		// carry from h1 addition
+	ADD	X17, X16, X6		// h1 = h1 + msg[8:16] + carry
+	SLTU	X17, X6, X19		// carry from h1
+	OR	X19, X18, X18		// combined carry
+
+	// h2 += carry + 1 (for full 16-byte chunk)
+	ADDI	$1, X18, X18		// carry + 1
+	ADD	X7, X18, X7		// h2 += carry + 1
+
+	// Advance msg pointer
+	ADDI	$16, X11, X11		// msg = msg[16:]
+
+multiply:
+	// Multiply h by r: h * r mod 2^130 - 5
+	// Compute h0r0 = h0 * r0 (128-bit result)
+	MUL	X5, X8, X20		// h0r0.lo
+	MULHU	X5, X8, X21		// h0r0.hi
+
+	// Compute h1r0 = h1 * r0 (128-bit result)
+	MUL	X6, X8, X22		// h1r0.lo
+	MULHU	X6, X8, X23		// h1r0.hi
+
+	// Compute h2r0 = h2 * r0 (h2 is small, so hi should be 0)
+	MUL	X7, X8, X24		// h2r0.lo
+	MULHU	X7, X8, X25		// h2r0.hi (should be 0, checked later)
+
+	// Compute h0r1 = h0 * r1 (128-bit result)
+	MUL	X5, X9, X26		// h0r1.lo
+	MULHU	X5, X9, X18		// h0r1.hi (use X18 to avoid X27/G register)
+
+	// Compute h1r1 = h1 * r1 (128-bit result)
+	MUL	X6, X9, X28		// h1r1.lo
+	MULHU	X6, X9, X29		// h1r1.hi
+
+	// Compute h2r1 = h2 * r1 (h2 is small, so hi should be 0)
+	MUL	X7, X9, X30		// h2r1.lo
+	MULHU	X7, X9, X31		// h2r1.hi (should be 0, checked later)
+
+	// Check for overflow in h2r0 and h2r1
+	BNEZ	X25, overflow_h2r0
+	BNEZ	X31, overflow_h2r1
+
+	// Combine products:
+	// m0 = h0r0
+	// m1 = h1r0 + h0r1
+	// m2 = h2r0 + h1r1
+	// m3 = h2r1
+
+	// m1 = h1r0 + h0r1 (128-bit addition)
+	ADD	X22, X26, X17		// m1.lo = h1r0.lo + h0r1.lo
+	SLTU	X22, X17, X16		// carry from lo
+	ADD	X23, X18, X19		// m1.hi = h1r0.hi + h0r1.hi (X18 is h0r1.hi)
+	ADD	X19, X16, X19		// m1.hi += carry
+
+	// m2 = h2r0 + h1r1 (128-bit addition)
+	ADD	X24, X28, X23		// m2.lo = h2r0.lo + h1r1.lo
+	SLTU	X24, X23, X16		// carry from lo
+	ADD	X25, X29, X25		// m2.hi = h2r0.hi + h1r1.hi
+	ADD	X25, X16, X25		// m2.hi += carry
+
+	// m3 = h2r1
+	// X30 = m3.lo (h2r1.lo), X31 = m3.hi (h2r1.hi, should be 0)
+
+	// Now combine into 64-bit limbs:
+	// t0 = m0.lo
+	// t1 = m1.lo + m0.hi
+	// t2 = m2.lo + m1.hi
+	// t3 = m3.lo + m2.hi
+
+	MOV	X20, X5		// t0 = m0.lo (h0r0.lo)
+
+	// t1 = m1.lo + m0.hi
+	ADD	X17, X21, X6		// t1 = m1.lo + m0.hi
+	SLTU	X17, X6, X16		// carry
+	ADD	X19, X16, X19		// m1.hi += carry
+
+	// t2 = m2.lo + m1.hi
+	ADD	X23, X19, X7		// t2 = m2.lo + m1.hi
+	SLTU	X23, X7, X16		// carry
+	ADD	X25, X16, X25		// m2.hi += carry
+
+	// t3 = m3.lo + m2.hi
+	ADD	X30, X25, X14		// t3 = m3.lo + m2.hi
+
+	// Reduce modulo 2^130 - 5:
+	// Split t2 at bit 130: h2 = t2 & 3, cc = (t2 & ~3, t3)
+	// Save t2 before masking
+	MOV	X7, X15		// Save t2
+	ANDI	$3, X7, X7		// h2 = t2 & 3
+	ANDI	$-4, X15, X15		// cc.lo = t2 & ~3
+	MOV	X14, X16		// cc.hi = t3
+
+	// Add cc (c * 4) to h
+	ADD	X15, X5, X5		// h0 += cc.lo
+	SLTU	X15, X5, X17		// carry
+	ADD	X16, X6, X19		// h1 + cc.hi
+	SLTU	X16, X19, X18		// carry
+	ADD	X19, X17, X6		// h1 += cc.hi + carry
+	SLTU	X19, X6, X20		// carry
+	OR	X20, X18, X18		// combined carry
+	ADD	X7, X18, X7		// h2 += carry
+
+	// Shift cc right by 2: cc >> 2
+	SRLI	$2, X15, X15		// cc.lo >> 2
+	ANDI	$3, X16, X21		// Get low 2 bits of cc.hi
+	SLLI	$62, X21, X21		// Shift to high bits
+	OR	X21, X15, X15		// Combine
+	SRLI	$2, X16, X16		// cc.hi >> 2
+
+	// Add (cc >> 2) to h
+	ADD	X15, X5, X5		// h0 += (cc >> 2).lo
+	SLTU	X15, X5, X17		// carry
+	ADD	X16, X6, X19		// h1 + (cc >> 2).hi
+	SLTU	X16, X19, X18		// carry
+	ADD	X19, X17, X6		// h1 += (cc >> 2).hi + carry
+	SLTU	X19, X6, X20		// carry
+	OR	X20, X18, X18		// combined carry
+	ADD	X7, X18, X7		// h2 += carry
+
+	// Check if more 16-byte blocks to process
+	ADDI	$-16, X12, X12		// msg_len -= 16
+	BGEU	X12, X13, loop		// if msg_len >= 16, continue loop
+
+bytes_between_0_and_15:
+	BEQ	X12, X0, done		// if msg_len == 0, done
+
+	// Handle remaining bytes (< 16)
+	// Build buffer in registers: buf[0:8] in X14, buf[8:16] in X15
+	// Initialize with 1 at position len(msg)
+	MOV	$1, X14		// Start with 1 in low byte
+	XOR	X15, X15, X15	// Clear high part
+	ADD	X12, X11, X11	// msg = msg + len(msg) (point to end)
+
+flush_buffer:
+	// Load byte from end and shift into buffer
+	MOVBU	-1(X11), X16		// Load byte from msg[-1]
+	SRLI	$56, X14, X17		// Get high byte of X14
+	SLLI	$8, X15, X18		// Shift X15 left by 8
+	OR	X17, X18, X15		// Combine: X15 = (X15 << 8) | (X14 >> 56)
+	SLLI	$8, X14, X14		// Shift X14 left by 8
+	XOR	X16, X14, X14		// XOR byte into X14
+	ADDI	$-1, X12, X12		// Decrement length
+	ADDI	$-1, X11, X11		// Decrement pointer
+	BNEZ	X12, flush_buffer	// Continue if more bytes
+
+	// Add buffer to h
+	ADD	X14, X5, X5		// h0 += buf[0:8]
+	SLTU	X14, X5, X16		// carry
+	ADD	X15, X6, X17		// h1 + buf[8:16]
+	SLTU	X15, X17, X18		// carry
+	ADD	X17, X16, X6		// h1 += buf[8:16] + carry
+	SLTU	X17, X6, X19		// carry
+	OR	X19, X18, X18		// combined carry
+	ADD	X7, X18, X7		// h2 += carry
+
+	// Process as if it were a full 16-byte block
+	MOV	$16, X12		// Set length to 16 for multiply
+	JMP	multiply
+
+overflow_h2r0:
+	// Panic: h2r0.hi != 0
+	// This should not happen in normal operation
+	// For now, we'll just continue (could call panic)
+	JMP	multiply
+
+overflow_h2r1:
+	// Panic: h2r1.hi != 0
+	// This should not happen in normal operation
+	// For now, we'll just continue (could call panic)
+	JMP	multiply
+
+done:
+	// Store updated state
+	MOV	X5, (X10)		// h0
+	MOV	X6, 8(X10)		// h1
+	MOV	X7, 16(X10)		// h2
+	RET
+

--- a/src/vendor/golang.org/x/crypto/internal/poly1305/sum_riscv64.s
+++ b/src/vendor/golang.org/x/crypto/internal/poly1305/sum_riscv64.s
@@ -1,215 +1,152 @@
-// Copyright 2025 The Go Authors. All rights reserved.
+// Copyright 2026 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build gc && !purego && riscv64
+//go:build gc && !purego
 
-#include "textflag.h"
+#define LOAD32U(base, offset, tmp, dest) \
+	MOVBU	(offset+0*1)(base), dest; \
+	MOVBU	(offset+1*1)(base), tmp; \
+	SLL	$8, tmp; \
+	OR	tmp, dest; \
+	MOVBU	(offset+2*1)(base), tmp; \
+	SLL	$16, tmp; \
+	OR	tmp, dest; \
+	MOVBU	(offset+3*1)(base), tmp; \
+	SLL	$24, tmp; \
+	OR	tmp, dest
+
+#define LOAD64U(base, offset, tmp1, tmp2, dst) \
+	LOAD32U(base, offset, tmp1, dst); \
+	LOAD32U(base, offset+4, tmp1, tmp2); \
+	SLL	$32, tmp2; \
+	OR	tmp2, dst
 
 // func update(state *macState, msg []byte)
-TEXT ·update(SB),NOSPLIT,$0-32
-	MOV	state+0(FP), X10	// state pointer
-	MOV	msg_base+8(FP), X11	// msg base
-	MOV	msg_len+16(FP), X12	// msg length
+TEXT ·update(SB), $0-32
+	MOV	state+0(FP), X5
+	MOV	msg_base+8(FP), X6
+	MOV	msg_len+16(FP), X7
 
-	MOV	$16, X13		// TagSize = 16
+	MOV	$0x10, X8
 
-	// Load state: h0, h1, h2, r0, r1
-	MOV	(X10), X5		// h0
-	MOV	8(X10), X6		// h1
-	MOV	16(X10), X7		// h2
-	MOV	24(X10), X8		// r0
-	MOV	32(X10), X9		// r1
+	AND	$7, X6, X28
 
-	// Check if msg length >= 16
-	BLTU	X12, X13, bytes_between_0_and_15
+	MOV	(0*8)(X5), X9		// h0
+	MOV	(1*8)(X5), X10		// h1
+	MOV	(2*8)(X5), X11		// h2
+	MOV	(3*8)(X5), X12		// r0
+	MOV	(4*8)(X5), X13		// r1
+
+	BLT	X7, X8, bytes_between_0_and_15
 
 loop:
-	// Load 16 bytes from msg
-	MOV	(X11), X14		// msg[0:8]
-	MOV	8(X11), X15		// msg[8:16]
+	BEQZ	X28, aligned_load
 
-	// h0 += msg[0:8]
-	ADD	X14, X5, X5		// h0 = h0 + msg[0:8]
-	SLTU	X14, X5, X16		// carry from h0
+	LOAD64U(X6,0*8, X16, X18, X15)
+	LOAD64U(X6,1*8, X19, X20, X17)
+	JMP	block
 
-	// h1 += msg[8:16] + carry
-	ADD	X15, X6, X17		// h1 + msg[8:16]
-	SLTU	X15, X17, X18		// carry from h1 addition
-	ADD	X17, X16, X6		// h1 = h1 + msg[8:16] + carry
-	SLTU	X17, X6, X19		// carry from h1
-	OR	X19, X18, X18		// combined carry
+aligned_load:
+	MOV	(0*8)(X6), X15		// msg[0:8]
+	MOV	(1*8)(X6), X17		// msg[8:16]
 
-	// h2 += carry + 1 (for full 16-byte chunk)
-	ADDI	$1, X18, X18		// carry + 1
-	ADD	X7, X18, X7		// h2 += carry + 1
+block:
+	ADD	X15, X9, X9			// h0 (x1 + y1 = z1', if z1' < x1 then z1' overflow)
+	ADD	X17, X10, X22
+	SLTU	X15, X9, X19	// h0.carry
+	SLTU	X10, X22, X23
+	ADD	X22, X19, X10		// h1
+	SLTU	X22, X10, X19
+	OR	X19, X23, X19		// h1.carry
+	ADD	$0x01, X19, X19
+	ADD	X11, X19, X11		// h2
 
-	// Advance msg pointer
-	ADDI	$16, X11, X11		// msg = msg[16:]
+	ADD	$16, X6, X6			// msg = msg[16:]
 
 multiply:
-	// Multiply h by r: h * r mod 2^130 - 5
-	// Compute h0r0 = h0 * r0 (128-bit result)
-	MUL	X5, X8, X20		// h0r0.lo
-	MULHU	X5, X8, X21		// h0r0.hi
+	MUL	X9, X12, X15		// h0r0.lo
+	MULHU	X9, X12, X16	// h0r0.hi
+	MUL	X10, X12, X14		// h1r0.lo
+	MULHU	X10, X12, X17	// h1r0.hi
+	ADD	X14, X16, X16
+	SLTU	X14, X16, X19
+	ADD	X19, X17, X17
+	MUL	X11, X12, X20
+	ADD	X17, X20, X20
+	MUL	X9, X13, X14		// h0r1.lo
+	MULHU	X9, X13, X17	// h0r1.hi
+	ADD	X14, X16, X16
+	SLTU	X14, X16, X19
+	ADD	X19, X17, X17
+	MOV	X17, X9
+	MUL	X11, X13, X21		// h2r1
+	MUL	X10, X13, X14		// h1r1.lo
+	MULHU	X10, X13, X17	// h1r1.hi
+	ADD	X14, X20, X20
+	ADD	X17, X21, X22
+	SLTU	X14, X20, X19
+	ADD	X22, X19, X21
+	ADD	X9, X20, X20
+	SLTU	X9, X20, X19
+	ADD	X19, X21, X21
+	AND	$3, X20, X11
+	AND	$-4, X20, X18
+	ADD	X18, X15, X9
+	ADD	X21, X16, X22
+	SLTU	X18, X9, X19
+	SLTU	X21, X22, X23
+	ADD	X22, X19, X10
+	SLTU	X22, X10, X19
+	OR	X19, X23, X19
+	ADD	X19, X11, X11
+	SLL	$62, X21, X22
+	SRL	$2, X20, X23
+	SRL	$2, X21, X21
+	OR	X22, X23, X20
+	ADD	X20, X9, X9
+	ADD	X21, X10, X22
+	SLTU	X20, X9, X19
+	SLTU	X21, X22, X23
+	ADD	X22, X19, X10
+	SLTU	X22, X10, X19
+	OR	X19, X23, X19
+	ADD	X19, X11, X11
 
-	// Compute h1r0 = h1 * r0 (128-bit result)
-	MUL	X6, X8, X22		// h1r0.lo
-	MULHU	X6, X8, X23		// h1r0.hi
-
-	// Compute h2r0 = h2 * r0 (h2 is small, so hi should be 0)
-	MUL	X7, X8, X24		// h2r0.lo
-	MULHU	X7, X8, X25		// h2r0.hi (should be 0, checked later)
-
-	// Compute h0r1 = h0 * r1 (128-bit result)
-	MUL	X5, X9, X26		// h0r1.lo
-	MULHU	X5, X9, X18		// h0r1.hi (use X18 to avoid X27/G register)
-
-	// Compute h1r1 = h1 * r1 (128-bit result)
-	MUL	X6, X9, X28		// h1r1.lo
-	MULHU	X6, X9, X29		// h1r1.hi
-
-	// Compute h2r1 = h2 * r1 (h2 is small, so hi should be 0)
-	MUL	X7, X9, X30		// h2r1.lo
-	MULHU	X7, X9, X31		// h2r1.hi (should be 0, checked later)
-
-	// Check for overflow in h2r0 and h2r1
-	BNEZ	X25, overflow_h2r0
-	BNEZ	X31, overflow_h2r1
-
-	// Combine products:
-	// m0 = h0r0
-	// m1 = h1r0 + h0r1
-	// m2 = h2r0 + h1r1
-	// m3 = h2r1
-
-	// m1 = h1r0 + h0r1 (128-bit addition)
-	ADD	X22, X26, X17		// m1.lo = h1r0.lo + h0r1.lo
-	SLTU	X22, X17, X16		// carry from lo
-	ADD	X23, X18, X19		// m1.hi = h1r0.hi + h0r1.hi (X18 is h0r1.hi)
-	ADD	X19, X16, X19		// m1.hi += carry
-
-	// m2 = h2r0 + h1r1 (128-bit addition)
-	ADD	X24, X28, X23		// m2.lo = h2r0.lo + h1r1.lo
-	SLTU	X24, X23, X16		// carry from lo
-	ADD	X25, X29, X25		// m2.hi = h2r0.hi + h1r1.hi
-	ADD	X25, X16, X25		// m2.hi += carry
-
-	// m3 = h2r1
-	// X30 = m3.lo (h2r1.lo), X31 = m3.hi (h2r1.hi, should be 0)
-
-	// Now combine into 64-bit limbs:
-	// t0 = m0.lo
-	// t1 = m1.lo + m0.hi
-	// t2 = m2.lo + m1.hi
-	// t3 = m3.lo + m2.hi
-
-	MOV	X20, X5		// t0 = m0.lo (h0r0.lo)
-
-	// t1 = m1.lo + m0.hi
-	ADD	X17, X21, X6		// t1 = m1.lo + m0.hi
-	SLTU	X17, X6, X16		// carry
-	ADD	X19, X16, X19		// m1.hi += carry
-
-	// t2 = m2.lo + m1.hi
-	ADD	X23, X19, X7		// t2 = m2.lo + m1.hi
-	SLTU	X23, X7, X16		// carry
-	ADD	X25, X16, X25		// m2.hi += carry
-
-	// t3 = m3.lo + m2.hi
-	ADD	X30, X25, X14		// t3 = m3.lo + m2.hi
-
-	// Reduce modulo 2^130 - 5:
-	// Split t2 at bit 130: h2 = t2 & 3, cc = (t2 & ~3, t3)
-	// Save t2 before masking
-	MOV	X7, X15		// Save t2
-	ANDI	$3, X7, X7		// h2 = t2 & 3
-	ANDI	$-4, X15, X15		// cc.lo = t2 & ~3
-	MOV	X14, X16		// cc.hi = t3
-
-	// Add cc (c * 4) to h
-	ADD	X15, X5, X5		// h0 += cc.lo
-	SLTU	X15, X5, X17		// carry
-	ADD	X16, X6, X19		// h1 + cc.hi
-	SLTU	X16, X19, X18		// carry
-	ADD	X19, X17, X6		// h1 += cc.hi + carry
-	SLTU	X19, X6, X20		// carry
-	OR	X20, X18, X18		// combined carry
-	ADD	X7, X18, X7		// h2 += carry
-
-	// Shift cc right by 2: cc >> 2
-	SRLI	$2, X15, X15		// cc.lo >> 2
-	ANDI	$3, X16, X21		// Get low 2 bits of cc.hi
-	SLLI	$62, X21, X21		// Shift to high bits
-	OR	X21, X15, X15		// Combine
-	SRLI	$2, X16, X16		// cc.hi >> 2
-
-	// Add (cc >> 2) to h
-	ADD	X15, X5, X5		// h0 += (cc >> 2).lo
-	SLTU	X15, X5, X17		// carry
-	ADD	X16, X6, X19		// h1 + (cc >> 2).hi
-	SLTU	X16, X19, X18		// carry
-	ADD	X19, X17, X6		// h1 += (cc >> 2).hi + carry
-	SLTU	X19, X6, X20		// carry
-	OR	X20, X18, X18		// combined carry
-	ADD	X7, X18, X7		// h2 += carry
-
-	// Check if more 16-byte blocks to process
-	ADDI	$-16, X12, X12		// msg_len -= 16
-	BGEU	X12, X13, loop		// if msg_len >= 16, continue loop
+	SUB	$16, X7, X7
+	BGE	X7, X8, loop
 
 bytes_between_0_and_15:
-	BEQ	X12, X0, done		// if msg_len == 0, done
-
-	// Handle remaining bytes (< 16)
-	// Build buffer in registers: buf[0:8] in X14, buf[8:16] in X15
-	// Initialize with 1 at position len(msg)
-	MOV	$1, X14		// Start with 1 in low byte
-	XOR	X15, X15, X15	// Clear high part
-	ADD	X12, X11, X11	// msg = msg + len(msg) (point to end)
+	BEQ	X7, X0, done
+	MOV	$1, X15
+	XOR	X16, X16
+	ADD	X7, X6, X6
 
 flush_buffer:
-	// Load byte from end and shift into buffer
-	MOVBU	-1(X11), X16		// Load byte from msg[-1]
-	SRLI	$56, X14, X17		// Get high byte of X14
-	SLLI	$8, X15, X18		// Shift X15 left by 8
-	OR	X17, X18, X15		// Combine: X15 = (X15 << 8) | (X14 >> 56)
-	SLLI	$8, X14, X14		// Shift X14 left by 8
-	XOR	X16, X14, X14		// XOR byte into X14
-	ADDI	$-1, X12, X12		// Decrement length
-	ADDI	$-1, X11, X11		// Decrement pointer
-	BNEZ	X12, flush_buffer	// Continue if more bytes
+	MOVBU	-1(X6), X20
+	SRL	$56, X15, X19
+	SLL	$8, X16, X23
+	SLL	$8, X15, X15
+	OR	X19, X23, X16
+	XOR	X20, X15, X15
+	SUB	$1, X7, X7
+	SUB	$1, X6, X6
+	BNE	X7, X0, flush_buffer
 
-	// Add buffer to h
-	ADD	X14, X5, X5		// h0 += buf[0:8]
-	SLTU	X14, X5, X16		// carry
-	ADD	X15, X6, X17		// h1 + buf[8:16]
-	SLTU	X15, X17, X18		// carry
-	ADD	X17, X16, X6		// h1 += buf[8:16] + carry
-	SLTU	X17, X6, X19		// carry
-	OR	X19, X18, X18		// combined carry
-	ADD	X7, X18, X7		// h2 += carry
+	ADD	X15, X9, X9
+	SLTU	X15, X9, X19
+	ADD	X16, X10, X22
+	SLTU	X16, X22, X23
+	ADD	X22, X19, X10
+	SLTU	X22, X10, X19
+	OR	X19, X23, X19
+	ADD	X11, X19, X11
 
-	// Process as if it were a full 16-byte block
-	MOV	$16, X12		// Set length to 16 for multiply
-	JMP	multiply
-
-overflow_h2r0:
-	// Panic: h2r0.hi != 0
-	// This should not happen in normal operation
-	// For now, we'll just continue (could call panic)
-	JMP	multiply
-
-overflow_h2r1:
-	// Panic: h2r1.hi != 0
-	// This should not happen in normal operation
-	// For now, we'll just continue (could call panic)
+	MOV	$16, X7
 	JMP	multiply
 
 done:
-	// Store updated state
-	MOV	X5, (X10)		// h0
-	MOV	X6, 8(X10)		// h1
-	MOV	X7, 16(X10)		// h2
+	MOV	X9, (0*8)(X5)
+	MOV	X10, (1*8)(X5)
+	MOV	X11, (2*8)(X5)
 	RET
-


### PR DESCRIPTION
https://go-review.googlesource.com/c/crypto/+/738760
```
goos: linux
goarch: riscv64
pkg: [golang.org/x/crypto/internal/poly1305](http://golang.org/x/crypto/internal/poly1305)
                   │ sum1305-old  │            sum1305-new              │
                   │    sec/op    │   sec/op     vs base                │
64-4                  195.9n ± 1%   144.8n ± 0%  -26.07% (p=0.000 n=10)
1K-4                  1.853µ ± 0%   1.012µ ± 0%  -45.39% (p=0.000 n=10)
2M-4                  3.627m ± 0%   1.880m ± 0%  -48.17% (p=0.000 n=10)
64Unaligned-4         196.4n ± 1%   174.7n ± 0%  -11.05% (p=0.000 n=10)
1KUnaligned-4         1.853µ ± 0%   1.491µ ± 0%  -19.54% (p=0.000 n=10)
2MUnaligned-4         3.643m ± 0%   2.850m ± 0%  -21.78% (p=0.000 n=10)
Write64-4            126.85n ± 0%   77.40n ± 0%  -38.98% (p=0.000 n=10)
Write1K-4            1784.5n ± 1%   937.2n ± 0%  -47.48% (p=0.000 n=10)
Write2M-4             3.654m ± 2%   1.880m ± 0%  -48.55% (p=0.000 n=10)
Write64Unaligned-4    125.7n ± 0%   107.5n ± 0%  -14.48% (p=0.000 n=10)
Write1KUnaligned-4    1.782µ ± 0%   1.424µ ± 0%  -20.09% (p=0.000 n=10)
Write2MUnaligned-4    3.637m ± 0%   2.850m ± 0%  -21.64% (p=0.000 n=10)
geomean               10.14µ        6.925µ       -31.68%

                   │ sum1305-old  │             sum1305-new-3             │
                   │     B/s      │      B/s       vs base                │
64-4                 311.7Mi ± 1%    421.5Mi ± 0%  +35.25% (p=0.000 n=10)
1K-4                 527.0Mi ± 0%    965.0Mi ± 0%  +83.10% (p=0.000 n=10)
2M-4                 551.4Mi ± 0%   1063.8Mi ± 0%  +92.94% (p=0.000 n=10)
64Unaligned-4        310.8Mi ± 1%    349.3Mi ± 0%  +12.38% (p=0.000 n=10)
1KUnaligned-4        526.9Mi ± 0%    654.9Mi ± 0%  +24.30% (p=0.000 n=10)
2MUnaligned-4        548.9Mi ± 0%    701.8Mi ± 0%  +27.85% (p=0.000 n=10)
Write64-4            481.2Mi ± 0%    788.6Mi ± 0%  +63.89% (p=0.000 n=10)
Write1K-4            547.2Mi ± 1%   1042.0Mi ± 0%  +90.42% (p=0.000 n=10)
Write2M-4            547.4Mi ± 2%   1064.0Mi ± 0%  +94.38% (p=0.000 n=10)
Write64Unaligned-4   485.5Mi ± 0%    567.7Mi ± 0%  +16.94% (p=0.000 n=10)
Write1KUnaligned-4   547.9Mi ± 0%    685.8Mi ± 0%  +25.17% (p=0.000 n=10)
Write2MUnaligned-4   550.0Mi ± 0%    701.9Mi ± 0%  +27.62% (p=0.000 n=10)
geomean              485.5Mi         710.7Mi       +46.37%
```
Change-Id: [I33a3df03382eb42ef062b0366521f02559290482](https://go-review.googlesource.com/q/I33a3df03382eb42ef062b0366521f02559290482)