### PR TITLE
cmd/internal/obj/riscv: Reuse REG_TMP for consecutive memory access with large offset

### DIFF
--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -32,6 +32,7 @@ import (
 	"math"
 	"math/bits"
 	"strings"
+	"sync"
 )
 
 func buildop(ctxt *obj.Link) {}
@@ -738,6 +739,8 @@ func preprocess(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) {
 		stackOffset(&p.From, stacksize)
 		stackOffset(&p.To, stacksize)
 	}
+
+	optimizeMemAddrRegTmpReuse(cursym.Func().Text)
 
 	// Additional instruction rewriting.
 	for p := cursym.Func().Text; p != nil; p = p.Link {
@@ -2012,7 +2015,7 @@ func compressedEncoding(as obj.As) uint32 {
 		op = 0b101 << 13
 	// CSB Format
 	case ACSB:
-		op = 0b100010<<10
+		op = 0b100010 << 10
 	// CSH Format
 	case ACSH:
 		op = 0b100011<<10 | 0b0<<6
@@ -2190,12 +2193,14 @@ func encodeCS(ins *instruction) uint32 {
 	}
 	return compressedEncoding(ins.as) | ((imm>>2)&0x7)<<10 | regCI(ins.rs1)<<7 | (imm&3)<<5 | rs2<<2
 }
+
 // encodeCSB encodes a compressed store the least significant byte (CSB-type) instruction.
 func encodeCSB(ins *instruction) uint32 {
 	// Bit order [0|1]
 	imm := encodeBitPattern(uint32(ins.imm), []int{0, 1})
 	return compressedEncoding(ins.as) | regCI(ins.rs1)<<7 | (imm&0x3)<<5 | regCI(ins.rs2)<<2
 }
+
 // encodeCSH encodes a compressed store the least significant halfword (CSH-type) instruction.
 func encodeCSH(ins *instruction) uint32 {
 	// Bit order [1]
@@ -2625,9 +2630,9 @@ var (
 	cssEncoding = encoding{encode: encodeCSS, validate: validateCSS, length: 2}
 
 	// Zcb encodings
-	clbEncoding  = encoding{encode: encodeCLB, validate: validateCLB, length: 2}
-	clhEncoding  = encoding{encode: encodeCLH, validate: validateCLH, length: 2}
-	csbEncoding  = encoding{encode: encodeCSB, validate: validateCSB, length: 2}
+	clbEncoding = encoding{encode: encodeCLB, validate: validateCLB, length: 2}
+	clhEncoding = encoding{encode: encodeCLH, validate: validateCLH, length: 2}
+	csbEncoding = encoding{encode: encodeCSB, validate: validateCSB, length: 2}
 	cshEncoding = encoding{encode: encodeCSH, validate: validateCSH, length: 2}
 	cuEncoding  = encoding{encode: encodeCU, validate: validateCU, length: 2}
 
@@ -2988,14 +2993,14 @@ var instructions = [ALAST & obj.AMask]instructionData{
 	// 27.8: "zcb" Extension for simple code-size saving instruction
 	ACLBU & obj.AMask:   {enc: clbEncoding},
 	ACLHU & obj.AMask:   {enc: clhEncoding},
-	ACLH & obj.AMask:   {enc: clhEncoding},
-	ACSB & obj.AMask:   {enc: csbEncoding},
-	ACSH & obj.AMask:   {enc: cshEncoding},
-	ACZEXTB & obj.AMask:   {enc: cuEncoding},
-	ACSEXTB & obj.AMask:   {enc: cuEncoding},
-	ACZEXTH & obj.AMask:   {enc: cuEncoding},
-	ACSEXTH & obj.AMask:   {enc: cuEncoding},
-	ACZEXTW & obj.AMask:   {enc: cuEncoding},
+	ACLH & obj.AMask:    {enc: clhEncoding},
+	ACSB & obj.AMask:    {enc: csbEncoding},
+	ACSH & obj.AMask:    {enc: cshEncoding},
+	ACZEXTB & obj.AMask: {enc: cuEncoding},
+	ACSEXTB & obj.AMask: {enc: cuEncoding},
+	ACZEXTH & obj.AMask: {enc: cuEncoding},
+	ACSEXTH & obj.AMask: {enc: cuEncoding},
+	ACZEXTW & obj.AMask: {enc: cuEncoding},
 	ACNOT & obj.AMask:   {enc: cuEncoding},
 	ACMUL & obj.AMask:   {enc: caEncoding, ternary: true},
 
@@ -4014,7 +4019,7 @@ func (ins *instruction) compress() {
 		}
 
 	case ALBU:
-		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && immUFits(ins.imm, 2) == nil{
+		if isIntPrimeReg(ins.rd) && isIntPrimeReg(ins.rs1) && immUFits(ins.imm, 2) == nil {
 			ins.as = ACLBU
 		}
 
@@ -4104,7 +4109,7 @@ func (ins *instruction) compress() {
 	case AANDI:
 		if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && immIFits(ins.imm, 6) == nil {
 			ins.as = ACANDI
-		} else if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1  && ins.imm == 0xff {
+		} else if isIntPrimeReg(ins.rd) && ins.rd == ins.rs1 && ins.imm == 0xff {
 			ins.as = ACZEXTB
 		}
 
@@ -4290,6 +4295,14 @@ func instructionsForLoad(p *obj.Prog, as obj.As, rs int16) []*instruction {
 		return []*instruction{ins}
 	}
 
+	// Check if we can reuse a previous address calculation (REG_TMP = base + (high<<12)); use REG_TMP+low.
+	if p.From.Name == obj.NAME_AUTO || p.From.Name == obj.NAME_PARAM || p.From.Name == obj.NAME_NONE {
+		if _, ok := memAddrRegTmpReuseMap.Load(p); ok {
+			ins.rs1, ins.imm = REG_TMP, low
+			return []*instruction{ins}
+		}
+	}
+
 	// LUI $high, TMP
 	// ADD TMP, REG, TMP
 	// <load> $low, TMP, TO
@@ -4328,6 +4341,14 @@ func instructionsForStore(p *obj.Prog, as obj.As, rd int16) []*instruction {
 	}
 	if high == 0 {
 		return []*instruction{ins}
+	}
+
+	// Check if we can reuse a previous address calculation (REG_TMP = base + (high<<12)); use REG_TMP+low.
+	if p.To.Name == obj.NAME_AUTO || p.To.Name == obj.NAME_PARAM || p.To.Name == obj.NAME_NONE {
+		if _, ok := memAddrRegTmpReuseMap.Load(p); ok {
+			ins.rd, ins.imm = REG_TMP, low
+			return []*instruction{ins}
+		}
 	}
 
 	// LUI $high, TMP
@@ -5605,11 +5626,171 @@ func assemble(ctxt *obj.Link, cursym *obj.LSym, newprog obj.ProgAlloc) {
 		}
 	}
 
+	// Remove this function's progs from memAddrRegTmpReuseMap now that codegen is done,
+	// so we do not retain *obj.Prog keys that may be freed (avoids "pointer to free object").
+	clearMemAddrRegTmpReuseMapForProgs(cursym.Func().Text)
+
 	obj.MarkUnsafePoints(ctxt, cursym.Func().Text, newprog, isUnsafePoint, nil)
 }
 
 func isUnsafePoint(p *obj.Prog) bool {
 	return p.Mark&USES_REG_TMP == USES_REG_TMP || p.From.Reg == REG_TMP || p.To.Reg == REG_TMP || p.Reg == REG_TMP
+}
+
+// memAddrRegTmpReuseMap marks Progs whose memory address can reuse REG_TMP from the
+// previous LUI+ADD (same base reg, same high, no jump target, prev doesn't clobber base).
+// Applies to any base register (e.g. SP, SB).
+var memAddrRegTmpReuseMap sync.Map
+
+// clearMemAddrRegTmpReuseMapForProgs removes all entries for the given prog list from memAddrRegTmpReuseMap.
+// Call this after codegen for a function is done so we do not retain *obj.Prog keys.
+func clearMemAddrRegTmpReuseMapForProgs(text *obj.Prog) {
+	for p := text; p != nil; p = p.Link {
+		memAddrRegTmpReuseMap.Delete(p)
+	}
+}
+
+// optimizeMemAddrRegTmpReuse marks consecutive LUI+ADD+load/store groups that share the
+// same base register so only the first in each run emits LUI+ADD; the rest reuse REG_TMP.
+func optimizeMemAddrRegTmpReuse(text *obj.Prog) {
+	var progs []*obj.Prog
+	for p := text; p != nil; p = p.Link {
+		progs = append(progs, p)
+	}
+	for _, p := range progs {
+		memAddrRegTmpReuseMap.Delete(p)
+	}
+
+	// Collect all branch/call targets in this function. We must not optimize a prog
+	// that can be reached by a jump, because then the "previous" prog's LUI+ADD
+	// may not have been executed and REG_TMP would be wrong.
+	targets := make(map[*obj.Prog]bool)
+	for _, q := range progs {
+		if q.To.Type == obj.TYPE_BRANCH && q.To.Target() != nil {
+			targets[q.To.Target()] = true
+		}
+		// JAL with target is an intra-function call (or jump); target can be reached without going through prev.
+		if (q.As == AJAL || q.As == ACJALR) && q.To.Target() != nil {
+			targets[q.To.Target()] = true
+		}
+	}
+
+	for i, p := range progs {
+		var baseReg int16 = -1
+		var offset int64
+		var isMemAccess bool
+
+		// Only optimize actual load/store (TYPE_MEM). TYPE_ADDR (LEA) uses instructionsForOpImmediate
+		// and does not use memAddrRegTmpReuseMap, so skip it.
+		if p.From.Type == obj.TYPE_MEM && (p.From.Name == obj.NAME_AUTO || p.From.Name == obj.NAME_PARAM || p.From.Name == obj.NAME_NONE) {
+			baseReg = p.From.Reg
+			offset = p.From.Offset
+			isMemAccess = true
+		} else if p.To.Type == obj.TYPE_MEM && (p.To.Name == obj.NAME_AUTO || p.To.Name == obj.NAME_PARAM || p.To.Name == obj.NAME_NONE) {
+			baseReg = p.To.Reg
+			offset = p.To.Offset
+			isMemAccess = true
+		}
+
+		if !isMemAccess {
+			continue
+		}
+
+		_, high, err := Split32BitImmediate(offset)
+		if err != nil {
+			continue
+		}
+		if high == 0 {
+			continue
+		}
+
+		// Only consider the immediately preceding Prog—no other instruction in between
+		if i == 0 {
+			continue
+		}
+		prev := progs[i-1]
+
+		// prev must be a load/store (TYPE_MEM) that actually emits LUI+ADD into REG_TMP.
+		// TYPE_ADDR (LEA) uses instructionsForOpImmediate and writes the result to p.To.Reg,
+		// not REG_TMP, so reusing REG_TMP after a LEA would use the wrong value and corrupt memory.
+		var prevOffset int64
+		var prevBaseReg int16 = -1
+		var prevIsMemAccess bool
+
+		if prev.From.Type == obj.TYPE_MEM && (prev.From.Name == obj.NAME_AUTO || prev.From.Name == obj.NAME_PARAM || prev.From.Name == obj.NAME_NONE) {
+			prevOffset, prevBaseReg = prev.From.Offset, prev.From.Reg
+			prevIsMemAccess = true
+		} else if prev.To.Type == obj.TYPE_MEM && (prev.To.Name == obj.NAME_AUTO || prev.To.Name == obj.NAME_PARAM || prev.To.Name == obj.NAME_NONE) {
+			prevOffset, prevBaseReg = prev.To.Offset, prev.To.Reg
+			prevIsMemAccess = true
+		}
+
+		// Do not use prev.From.Type == obj.TYPE_ADDR: LEA does not leave REG_TMP with the base address.
+		if !prevIsMemAccess || prevBaseReg != baseReg {
+			continue
+		}
+
+		// Prev must not write the base register, or REG_TMP (holding base+high) would be used with a stale base.
+		if prev.To.Type == obj.TYPE_REG && prev.To.Reg == baseReg {
+			continue
+		}
+
+		// If prev is a Load whose destination is REG_TMP, REG_TMP is overwritten with the loaded
+		// value, not the address, so the next instruction cannot reuse REG_TMP.
+		if prev.From.Type == obj.TYPE_MEM && prev.To.Type == obj.TYPE_REG && prev.To.Reg == REG_TMP {
+			continue
+		}
+
+		_, prevHigh, err := Split32BitImmediate(prevOffset)
+		if err != nil || prevHigh == 0 {
+			continue
+		}
+
+		diff := offset - prevOffset
+		absDiff := diff
+		if absDiff < 0 {
+			absDiff = -absDiff
+		}
+		if absDiff >= 2048 || high != prevHigh {
+			continue
+		}
+
+		// Do not optimize if any branch/jump targets this prog or any between prev and p.
+		// Then control flow could reach p without executing prev, so REG_TMP would be wrong.
+		skip := targets[p]
+		if !skip {
+			for q := prev.Link; q != nil && q != p; q = q.Link {
+				if targets[q] {
+					skip = true
+					break
+				}
+			}
+		}
+		if skip {
+			continue
+		}
+
+		// For stores only: avoid long runs of store instructions.
+		if p.To.Type == obj.TYPE_MEM {
+			runLen := 0
+			for j := i - 1; j >= 0; j-- {
+				q := progs[j]
+				if q.To.Type != obj.TYPE_MEM {
+					break
+				}
+				if _, ok := memAddrRegTmpReuseMap.Load(q); !ok {
+					break
+				}
+				runLen++
+			}
+			if runLen >= 3 {
+				continue
+			}
+		}
+
+		// Value is unused; presence of key means this prog can reuse REG_TMP.
+		memAddrRegTmpReuseMap.Store(p, struct{}{})
+	}
 }
 
 func ParseSuffix(prog *obj.Prog, cond string) (err error) {


### PR DESCRIPTION
<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

During testing golang/benchmarks, three benchmarks in the wazero library performed relatively poorly. When capturing hot functions in the SG server environment, it was found that the hot function in all cases was callNativeFunc, with CPU time reaching 97% in each. This function is a pure Go function implemented by wazero. Static code analysis revealed that it generates an excessively large number of memory-access-related instructions. Compared to the 31,901 lines shown in the ARM disassembly, the RISC-V instruction count reached 49,317 lines. The reasons for this instruction bloat are as follows:

- RISC-V lacks instructions similar to ARM's LDP and STP, which can load or store two registers at once.
- RISC-V's immediate values are only 12 bits wide, limiting the size of offset addresses.

Currently, the lack of instructions cannot be supplemented. However, when calculating memory access addresses, if the offset exceeds the 12-bit immediate limit, two additional instructions—LUI and ADD—are generated to compute a new base address. At present, this handling is applied uniformly in such scenarios, but many of these LUI and ADD calculations are redundant and could be reused from previous results.

## Solution
During preprocess, memory-access prog nodes eligible for address-base reuse are identified and marked. In instructionsForLoad/Store, a marked node emits only the memory operation with REG_TMP+low, omitting LUI+ADD.

Reuse is allowed only if the current and previous instructions are both optimizable TYPE_MEM accesses, share the same base register, have identical immediate high parts, and the offset delta is < 2048; additionally, the previous instruction must not clobber the base register or overwrite REG_TMP.

Control-flow safety is enforced: neither the current node nor any node in the prev->p interval may be a branch/jump landing target, preventing reuse on paths where the prior address computation is not guaranteed to execute.

For store operations, consecutive reuse length is capped to avoid regressions from excessively long optimized store chains.

## Performance data
Tested on SG2044, taskset to an idle core:
```
goos: linux
goarch: riscv64
pkg: github.com/tetratelabs/wazero/internal/integration_test/bench
                                                   │ sg_old.txt  │            sg_new.txt             │
                                                   │   sec/op    │   sec/op     vs base              │
Invocation/interpreter/fib_for_20                    9.194m ± 2%   8.515m ± 1%  -7.38% (p=0.002 n=6)
Invocation/interpreter/string_manipulation_size_50   3.916m ± 7%   3.638m ± 6%  -7.09% (p=0.004 n=6)
Invocation/interpreter/random_mat_mul_size_20        24.75m ± 1%   23.72m ± 0%  -4.17% (p=0.002 n=6)
geomean                                              9.623m        9.023m       -6.23%
```

## Todo
The existing implementation is limited to reuse scenarios involving consecutive memory access operations, with no other instructions interspersed, which restricts its practicality. Work is already underway to support interleaving other instructions, but an issue has currently been encountered where certain incorrect reuse optimizations result in the use of a modified `REG_TMP`, causing a segmentation violation. Once this is resolved, a new PR will be submitted as a supplement.

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required