### PR TITLE
cmd/internal/obj/riscv: relocate morestack call to function tail for branch prediction

### DIFF
--- a/src/cmd/internal/obj/riscv/obj.go
+++ b/src/cmd/internal/obj/riscv/obj.go
@@ -1074,19 +1074,19 @@ func stacksplit(ctxt *obj.Link, p *obj.Prog, cursym *obj.LSym, newprog obj.ProgA
 	// unnecessarily. See issue #35470.
 	p = ctxt.StartUnsafePoint(p, newprog)
 
-	var to_done, to_more *obj.Prog
+	var to_more, to_more_big *obj.Prog
 
 	if framesize <= abi.StackSmall {
 		// small stack
-		//	// if SP > stackguard { goto done }
-		//	BLTU	stackguard, SP, done
+		//	// if SP <= stackguard { goto label-of-call-to-morestack }
+		//	BLEU	SP, stackguard, label-of-call-to-morestack
 		p = obj.Appendp(p, newprog)
-		p.As = ABLTU
+		p.As = ABLEU
 		p.From.Type = obj.TYPE_REG
-		p.From.Reg = REG_X6
-		p.Reg = REG_SP
+		p.From.Reg = REG_SP
+		p.Reg = REG_X6
 		p.To.Type = obj.TYPE_BRANCH
-		to_done = p
+		to_more = p
 	} else {
 		// large stack: SP-framesize < stackguard-StackSmall
 		offset := int64(framesize) - abi.StackSmall
@@ -1114,13 +1114,13 @@ func stacksplit(ctxt *obj.Link, p *obj.Prog, cursym *obj.LSym, newprog obj.ProgA
 			p.From.Reg = REG_SP
 			p.Reg = REG_X7
 			p.To.Type = obj.TYPE_BRANCH
-			to_more = p
+			to_more_big = p
 		}
 
 		// Check against the stack guard. We've ensured this won't underflow.
 		//	ADD	$-(framesize-StackSmall), SP, X7
-		//	// if X7 > stackguard { goto done }
-		//	BLTU	stackguard, X7, done
+		//	// if X7 <= stackguard { goto label-of-call-to-morestack }
+		//	BLEU	X7, stackguard, label-of-call-to-morestack
 		p = obj.Appendp(p, newprog)
 		p.As = AADDI
 		p.From.Type = obj.TYPE_CONST
@@ -1130,17 +1130,37 @@ func stacksplit(ctxt *obj.Link, p *obj.Prog, cursym *obj.LSym, newprog obj.ProgA
 		p.To.Reg = REG_X7
 
 		p = obj.Appendp(p, newprog)
-		p.As = ABLTU
+		p.As = ABLEU
 		p.From.Type = obj.TYPE_REG
-		p.From.Reg = REG_X6
-		p.Reg = REG_X7
+		p.From.Reg = REG_X7
+		p.Reg = REG_X6
 		p.To.Type = obj.TYPE_BRANCH
-		to_done = p
+		to_more = p
 	}
+
+	end := ctxt.EndUnsafePoint(p, newprog, -1)
+
+	var last *obj.Prog
+	for last = cursym.Func().Text; last.Link != nil; last = last.Link {
+	}
+
+	// Now we are at the end of the function, but logically
+	// we are still in function prologue. We need to fix the
+	// SP data and PCDATA.
+	p = obj.Appendp(last, newprog)
+	p.As = obj.ANOP
+	p.Spadj = -int32(framesize)
+
+	p = ctxt.EmitEntryStackMap(cursym, p, newprog)
+	p = ctxt.StartUnsafePoint(p, newprog)
+
+	if to_more_big != nil {
+		to_more_big.To.SetTarget(p)
+	}
+	to_more.To.SetTarget(p)
 
 	// Spill the register args that could be clobbered by the
 	// morestack code
-	p = ctxt.EmitEntryStackMap(cursym, p, newprog)
 	p = cursym.Func().SpillRegisterArgs(p, newprog)
 
 	// CALL runtime.morestack(SB)
@@ -1155,12 +1175,8 @@ func stacksplit(ctxt *obj.Link, p *obj.Prog, cursym *obj.LSym, newprog obj.ProgA
 	} else {
 		p.To.Sym = ctxt.Lookup("runtime.morestack")
 	}
-	if to_more != nil {
-		to_more.To.SetTarget(p)
-	}
 	jalToSym(ctxt, p, REG_X5)
 
-	// The instructions which unspill regs should be preemptible.
 	p = ctxt.EndUnsafePoint(p, newprog, -1)
 	p = cursym.Func().UnspillRegisterArgs(p, newprog)
 
@@ -1170,13 +1186,9 @@ func stacksplit(ctxt *obj.Link, p *obj.Prog, cursym *obj.LSym, newprog obj.ProgA
 	p.To = obj.Addr{Type: obj.TYPE_BRANCH}
 	p.From = obj.Addr{Type: obj.TYPE_REG, Reg: REG_ZERO}
 	p.To.SetTarget(startPred.Link)
+	p.Spadj = int32(framesize)
 
-	// placeholder for to_done's jump target
-	p = obj.Appendp(p, newprog)
-	p.As = obj.ANOP // zero-width place holder
-	to_done.To.SetTarget(p)
-
-	return p
+	return end
 }
 
 // signExtend sign extends val starting at bit bit.


### PR DESCRIPTION
## Related Issue(s) & Descriptions
**Motivation**
On riscv64, the `morestack` call was located in the function prologue.
This keeps a cold/rare path in the hot entry sequence, which is not ideal for instruction locality and branch prediction.

**What this commit does**
This change moves the `morestack` path to a tail cold block in cmd/internal/obj/riscv:
- Keep stack-split checks in the prologue.
- Relocate morestack call to function tail (i.e. cold block). 
- Branch to a cold block only when stack growth is needed.
- Jump back to the stack-check start after morestack returns.
- Preserve stack/PC metadata handling (Spadj, entry stack map, unsafe-point boundaries) so unwind/GC behavior remains correct.

**Result**
The hot prologue path is cleaner, while stack-growth behavior remains unchanged functionally.
We observe significant performance improvement across series of benchmarks.
`all.bash` was passed on riscv machine.

**Reference**
https://go-review.googlesource.com/c/go/+/534756
Compared to the code shown in the link above, this commit makes non-functional changes to improve code readability.

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required