### PR TITLE
cmd/compile: forward small Load through Move to avoid redundant copies

### DIFF
--- a/src/cmd/compile/internal/ssa/_gen/generic.rules
+++ b/src/cmd/compile/internal/ssa/_gen/generic.rules
@@ -765,6 +765,12 @@
 	&& disjoint(p5, t5.Size(), p4, t4.Size())
 	=> x
 
+// Load from a region just copied by Move can read directly from the source.
+(Load <t1> op:(OffPtr [o1] p1) move:(Move [n] p2 src mem))
+	&& o1 >= 0 && o1+t1.Size() <= n && isSamePtr(p1, p2)
+	&& !isVolatile(src)
+	=> @move.Block (Load <t1> (OffPtr <op.Type> [o1] src) mem)
+
 // Pass constants through math.Float{32,64}bits and math.Float{32,64}frombits
 (Load <t1> p1 (Store {t2} p2 (Const64  [x]) _)) && isSamePtr(p1,p2) && t2.Size() == 8 && is64BitFloat(t1) && !math.IsNaN(math.Float64frombits(uint64(x))) => (Const64F [math.Float64frombits(uint64(x))])
 (Load <t1> p1 (Store {t2} p2 (Const32  [x]) _)) && isSamePtr(p1,p2) && t2.Size() == 4 && is32BitFloat(t1) && !math.IsNaN(float64(math.Float32frombits(uint32(x)))) => (Const32F [math.Float32frombits(uint32(x))])

--- a/src/cmd/compile/internal/ssa/rewritegeneric.go
+++ b/src/cmd/compile/internal/ssa/rewritegeneric.go
@@ -13716,6 +13716,37 @@ func rewriteValuegeneric_OpLoad(v *Value) bool {
 		v.copyOf(x)
 		return true
 	}
+	// match: (Load <t1> op:(OffPtr [o1] p1) move:(Move [n] p2 src mem))
+	// cond: o1 >= 0 && o1+t1.Size() <= n && isSamePtr(p1, p2) && !isVolatile(src)
+	// result: @move.Block (Load <t1> (OffPtr <op.Type> [o1] src) mem)
+	for {
+		t1 := v.Type
+		op := v_0
+		if op.Op != OpOffPtr {
+			break
+		}
+		o1 := auxIntToInt64(op.AuxInt)
+		p1 := op.Args[0]
+		move := v_1
+		if move.Op != OpMove {
+			break
+		}
+		n := auxIntToInt64(move.AuxInt)
+		mem := move.Args[2]
+		p2 := move.Args[0]
+		src := move.Args[1]
+		if !(o1 >= 0 && o1+t1.Size() <= n && isSamePtr(p1, p2) && !isVolatile(src)) {
+			break
+		}
+		b = move.Block
+		v0 := b.NewValue0(v.Pos, OpLoad, t1)
+		v.copyOf(v0)
+		v1 := b.NewValue0(v.Pos, OpOffPtr, op.Type)
+		v1.AuxInt = int64ToAuxInt(o1)
+		v1.AddArg(src)
+		v0.AddArg2(v1, mem)
+		return true
+	}
 	// match: (Load <t1> p1 (Store {t2} p2 (Const64 [x]) _))
 	// cond: isSamePtr(p1,p2) && t2.Size() == 8 && is64BitFloat(t1) && !math.IsNaN(math.Float64frombits(uint64(x)))
 	// result: (Const64F [math.Float64frombits(uint64(x))])

--- a/src/cmd/compile/internal/test/moveload_test.go
+++ b/src/cmd/compile/internal/test/moveload_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package test
+
+import "testing"
+
+// From issue #77720.
+type moveLoadBenchHandle[T any] struct {
+	value *T
+}
+
+func (h moveLoadBenchHandle[T]) Value() T {
+	return *h.value
+}
+
+type moveLoadBenchBig struct {
+	typ        int8
+	index      int64
+	str        string
+	pkgID      string
+	dummyField [1024]byte
+}
+
+type moveLoadBenchS struct {
+	h moveLoadBenchHandle[moveLoadBenchBig]
+}
+
+var moveLoadBenchSink int8
+
+func moveLoadBenchTypViaValue(s moveLoadBenchS) int8 {
+	return s.h.Value().typ
+}
+
+func moveLoadBenchTypViaPtr(s moveLoadBenchS) int8 {
+	return (*s.h.value).typ
+}
+
+func benchmarkMoveLoad(b *testing.B, f func(moveLoadBenchS) int8) {
+	backing := make([]moveLoadBenchBig, 1<<10)
+	ss := make([]moveLoadBenchS, len(backing))
+	for i := range backing {
+		backing[i].typ = int8(i)
+		ss[i] = moveLoadBenchS{h: moveLoadBenchHandle[moveLoadBenchBig]{&backing[i]}}
+	}
+
+	b.ResetTimer()
+	var x int8
+	for i := 0; i < b.N; i++ {
+		x += f(ss[i&(len(ss)-1)])
+	}
+	moveLoadBenchSink = x
+}
+
+func BenchmarkMoveLoadTypViaValue(b *testing.B) {
+	benchmarkMoveLoad(b, moveLoadBenchTypViaValue)
+}
+
+func BenchmarkMoveLoadTypViaPtr(b *testing.B) {
+	benchmarkMoveLoad(b, moveLoadBenchTypViaPtr)
+}

--- a/test/codegen/moveload.go
+++ b/test/codegen/moveload.go
@@ -1,0 +1,38 @@
+// asmcheck
+
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package codegen
+
+// From issue #77720: cmd/compile: field access on struct-returning method copies entire struct
+
+type moveLoadBig struct {
+	typ   int8
+	index int64
+	str   string
+	pkgID string
+}
+
+type moveLoadHandle[T any] struct {
+	value *T
+}
+
+func (h moveLoadHandle[T]) Value() T { return *h.value }
+
+type moveLoadS struct {
+	h moveLoadHandle[moveLoadBig]
+}
+
+func moveLoadFieldViaValue(s moveLoadS) int8 {
+	// amd64:-`MOVUPS`
+	// amd64:`MOVBLZX`
+	return s.h.Value().typ
+}
+
+func moveLoadFieldViaValueInline(ss []moveLoadS, i int) int8 {
+	// amd64:-`MOVUPS`
+	// amd64:`MOVBLZX`
+	return ss[i&7].h.Value().typ
+}

--- a/test/fixedbugs/issue22200.go
+++ b/test/fixedbugs/issue22200.go
@@ -7,14 +7,16 @@
 package p
 
 func f1(x *[1<<30 - 1e6]byte) byte {
+	sum := byte(0)
 	for _, b := range *x {
-		return b
+		sum += b
 	}
-	return 0
+	return sum
 }
 func f2(x *[1<<30 + 1e6]byte) byte { // GC_ERROR "stack frame too large"
+	sum := byte(0)
 	for _, b := range *x {
-		return b
+		sum += b
 	}
-	return 0
+	return sum
 }

--- a/test/fixedbugs/issue22200b.go
+++ b/test/fixedbugs/issue22200b.go
@@ -9,20 +9,23 @@
 package p
 
 func f3(x *[1 << 31]byte) byte { // GC_ERROR "stack frame too large"
+	sum := byte(0)
 	for _, b := range *x {
-		return b
+		sum += b
 	}
-	return 0
+	return sum
 }
 func f4(x *[1 << 32]byte) byte { // GC_ERROR "stack frame too large"
+	sum := byte(0)
 	for _, b := range *x {
-		return b
+		sum += b
 	}
-	return 0
+	return sum
 }
 func f5(x *[1 << 33]byte) byte { // GC_ERROR "stack frame too large"
+	sum := byte(0)
 	for _, b := range *x {
-		return b
+		sum += b
 	}
-	return 0
+	return sum
 }


### PR DESCRIPTION



## Related Issue(s) & Descriptions
ref: https://go-review.googlesource.com/c/go/+/748200

Fixes #77720

Add a generic SSA rewrite that forwards `Load` from a `Move` destination back to the `Move` source when it is provably safe, so field reads like `s.h.Value().typ` don’t force a full struct copy.

- Add `Load <- Move` rewrite in `generic.rules` with safety guard: non-volatile source
- Tweak `fixedbugs/issue22200*` so that it can still trigger the "stack frame too large" error.
- Regenerate `rewritegeneric.go`.
- Add `test/codegen/moveload.go` to assert no `MOVUPS` and direct `MOVBLZX` in both direct and inlined forms.

Benchmark results (linux/amd64, i7-14700KF):

$ go test cmd/compile/internal/test -run='^$' -bench='MoveLoad' -count=20

Before:
  BenchmarkMoveLoadTypViaValue-20  ~76.9 ns/op
  BenchmarkMoveLoadTypViaPtr-20    ~1.97 ns/op

After:
  BenchmarkMoveLoadTypViaValue-20  ~1.894 ns/op
  BenchmarkMoveLoadTypViaPtr-20    ~1.905 ns/op

The rewrite removes the redundant struct copy in
`s.h.Value().typ`, bringing it in line with the direct pointer form.

Change-Id: Iddf2263e390030ba013e0642a695b87c75f899da
Reviewed-on: https://go-review.googlesource.com/c/go/+/748200
Reviewed-by: Keith Randall <khr@google.com>
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
Reviewed-by: Keith Randall <khr@golang.org>
Auto-Submit: Keith Randall <khr@golang.org>
Reviewed-by: Mark Freeman <markfreeman@google.com>
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required