### PR TITLE
cmd/compile: fix errors in zbs rules

### DIFF
--- a/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
@@ -550,18 +550,18 @@
 (B(EQ|NE)Z (AND x (SLLI [c] (MOVDconst [1]))) yes no) && c < 64 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 (B(EQ|NE)Z (AND x (SLLIW [c] (MOVDconst [1]))) yes no) && c < 31 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 
-// Pattern: 32-bit bit test with variable shift wrapped in MOVWUreg/MOVWreg
-// Matches: if uint32(x)&(1<<y) != 0 or int32(x)&(1<<y) != 0
-(B(EQ|NE)Z (MOVWUreg (AND x (SLL (MOVDconst [1]) y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
-(B(EQ|NE)Z (MOVWreg (AND x (SLL (MOVDconst [1]) y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
-
-// Pattern: 32-bit bit test with constant left shift wrapped in MOVWUreg/MOVWreg
-// Note: For SLLI (64-bit shift) wrapped in MOVWUreg/MOVWreg, only bits 0-31 are meaningful
-// because the 32-bit wrapper discards higher bits.
+// Pattern: 32-bit bit test with shift wrapped in MOVWUreg/MOVWreg
+// NOTE: Variable-shift without bounds guard is intentionally omitted because
+// MOVWUreg/MOVWreg truncates high bits when y >= 32, but BEXT reads the full 64-bit value.
+// For example: int32(x & (1 << 33)) always gives 0 (high bits truncated),
+// but BEXT x 33 returns bit 33 of x, producing incorrect results.
 (B(EQ|NE)Z (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 (B(EQ|NE)Z (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no) && c < 31 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 (B(EQ|NE)Z (MOVWreg (AND x (SLLI [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 (B(EQ|NE)Z (MOVWreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no) && c < 31 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
+// ANDI [c]-guarded variable shift: c <= 31 guarantees y & c < 32, so BEXT is safe.
+(B(EQ|NE)Z (MOVWUreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y)))) yes no) && c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x (ANDI <typ.UInt64> [c] y)) yes no)
+(B(EQ|NE)Z (MOVWreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y)))) yes no) && c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x (ANDI <typ.UInt64> [c] y)) yes no)
 
 // Pattern: Shift-right and test bit 0
 // Matches: if (x>>c)&1 != 0 with constant shift

--- a/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
@@ -538,33 +538,30 @@
 // Pattern: AND with constant mask (single bit)
 // Matches: if x&mask != 0 where mask is a power of two
 // Note: SSA canonicalizes commutative operations, so we only need one pattern
-(B(EQ|NE)Z (AND x (MOVDconst [c])) yes no) && oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 
+(B(EQ|NE)Z (AND x (MOVDconst [c])) yes no) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 
     => (B(EQ|NE)Z (BEXTI <typ.UInt64> [log64(c)] x) yes no)
 
 // Pattern: AND with variable shift (x & (1 << y))
 // Matches: if x&(1<<y) != 0
 (B(EQ|NE)Z (AND x (SLL (MOVDconst [1]) y)) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
-(B(EQ|NE)Z (AND x (SLLW (MOVDconst [1]) y)) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
 
 // Pattern: AND with constant left shift (x & (1 << c))
 // Matches: if x&(1<<c) != 0 where c is a constant
 (B(EQ|NE)Z (AND x (SLLI [c] (MOVDconst [1]))) yes no) && c < 64 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
-(B(EQ|NE)Z (AND x (SLLIW [c] (MOVDconst [1]))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
+(B(EQ|NE)Z (AND x (SLLIW [c] (MOVDconst [1]))) yes no) && c < 31 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 
 // Pattern: 32-bit bit test with variable shift wrapped in MOVWUreg/MOVWreg
 // Matches: if uint32(x)&(1<<y) != 0 or int32(x)&(1<<y) != 0
 (B(EQ|NE)Z (MOVWUreg (AND x (SLL (MOVDconst [1]) y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
-(B(EQ|NE)Z (MOVWUreg (AND x (SLLW (MOVDconst [1]) y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
 (B(EQ|NE)Z (MOVWreg (AND x (SLL (MOVDconst [1]) y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
-(B(EQ|NE)Z (MOVWreg (AND x (SLLW (MOVDconst [1]) y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
 
 // Pattern: 32-bit bit test with constant left shift wrapped in MOVWUreg/MOVWreg
 // Note: For SLLI (64-bit shift) wrapped in MOVWUreg/MOVWreg, only bits 0-31 are meaningful
 // because the 32-bit wrapper discards higher bits.
 (B(EQ|NE)Z (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
-(B(EQ|NE)Z (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
+(B(EQ|NE)Z (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no) && c < 31 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 (B(EQ|NE)Z (MOVWreg (AND x (SLLI [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
-(B(EQ|NE)Z (MOVWreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
+(B(EQ|NE)Z (MOVWreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no) && c < 31 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 
 // Pattern: Shift-right and test bit 0
 // Matches: if (x>>c)&1 != 0 with constant shift
@@ -584,11 +581,10 @@
 (B(EQ|NE)Z (MOVWUreg (ANDI [1] (SRL x y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
 (B(EQ|NE)Z (MOVWUreg (ANDI [1] (SRLW x y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
 
-// Pattern: Left shift and test bit 0 (less common but possible)
-// Matches: if ((x<<c)&1) != 0, which tests if bit (64-c) is set (for 64-bit) or (32-c) for 32-bit
-// Note: This is less common than right shift patterns
-(B(EQ|NE)Z (ANDI [1] (SLLI [c] x)) yes no) && c > 0 && c < 64 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [64-c] x) yes no)
-(B(EQ|NE)Z (ANDI [1] (SLLIW [c] x)) yes no) && c > 0 && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [32-c] x) yes no)
+// Pattern: (x << c) & 1 where c > 0 is always 0 (left shift fills low bits with zero).
+// Fold to constant branch to let later passes eliminate dead code.
+(B(EQ|NE)Z (ANDI [1] (SLLI [c] x)) yes no) && c > 0 => (B(EQ|NE)Z (MOVDconst [0]) yes no)
+(B(EQ|NE)Z (ANDI [1] (SLLIW [c] x)) yes no) && c > 0 => (B(EQ|NE)Z (MOVDconst [0]) yes no)
 
 // Optimize bit test patterns with mask after shift: (BEQZ|BNEZ) (ANDI [mask] (SRLI [c] x))
 // This matches patterns like "if (x>>c)&mask == 0" where mask is a power of two
@@ -767,8 +763,8 @@
 // This is because RISC-V I-type instructions have 12-bit signed immediates,
 // and constructing larger constants requires multiple instructions.
 // See issue 61694 (AMD64) for similar reasoning.
-(OR  (MOVDconst [c]) x) && oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BSETI [log64(c)] x)
-(XOR (MOVDconst [c]) x) && oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BINVI [log64(c)] x)
+(OR  (MOVDconst [c]) x) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BSETI [log64(c)] x)
+(XOR (MOVDconst [c]) x) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BINVI [log64(c)] x)
 
 // Recognize bit clearing with constant: a &^ (1<<c) where c >= 10
 // For c < 10, the constant can be encoded in ANDI immediate field

--- a/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
@@ -559,9 +559,11 @@
 (B(EQ|NE)Z (MOVWreg (AND x (SLLW (MOVDconst [1]) y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
 
 // Pattern: 32-bit bit test with constant left shift wrapped in MOVWUreg/MOVWreg
-(B(EQ|NE)Z (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))) yes no) && c < 64 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
+// Note: For SLLI (64-bit shift) wrapped in MOVWUreg/MOVWreg, only bits 0-31 are meaningful
+// because the 32-bit wrapper discards higher bits.
+(B(EQ|NE)Z (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 (B(EQ|NE)Z (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
-(B(EQ|NE)Z (MOVWreg (AND x (SLLI [c] (MOVDconst [1])))) yes no) && c < 64 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
+(B(EQ|NE)Z (MOVWreg (AND x (SLLI [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 (B(EQ|NE)Z (MOVWreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 
 // Pattern: Shift-right and test bit 0
@@ -576,8 +578,8 @@
 (B(EQ|NE)Z (ANDI [1] (SRLW x y)) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
 
 // Pattern: 32-bit bit test patterns with MOVWUreg wrapper
-(B(EQ|NE)Z (MOVWUreg (SRLIW [c] x)) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
-(B(EQ|NE)Z (MOVWUreg (ANDI [1] (SRLI [c] x))) yes no) && c < 64 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
+// Note: For SRLI (64-bit shift) wrapped in MOVWUreg, only bits 0-31 are meaningful
+(B(EQ|NE)Z (MOVWUreg (ANDI [1] (SRLI [c] x))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 (B(EQ|NE)Z (MOVWUreg (ANDI [1] (SRLIW [c] x))) yes no) && c < 32 && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [c] x) yes no)
 (B(EQ|NE)Z (MOVWUreg (ANDI [1] (SRL x y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
 (B(EQ|NE)Z (MOVWUreg (ANDI [1] (SRLW x y))) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXT <typ.UInt64> x y) yes no)
@@ -601,6 +603,10 @@
 // Optimize bit test patterns: (BEQZ|BNEZ) (SRLI [c] x) - check if bit c is set after shift
 // For c=63, x>>63 is 0 or 1, so we can use BEXTI to extract bit 63
 (B(EQ|NE)Z (SRLI [63] x) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [63] x) yes no)
+
+// Optimize bit test patterns for 32-bit unsigned right shift by 31.
+// For uint32, x>>31 is 0 or 1, so we can use BEXTI to extract bit 31.
+(B(EQ|NE)Z (MOVWUreg (SRLIW [31] x)) yes no) && buildcfg.GORISCV64 >= 22 => (B(EQ|NE)Z (BEXTI <typ.UInt64> [31] x) yes no)
 
 // Convert branch with zero to more optimal branch zero.
 (BEQ  (MOVDconst [0]) cond yes no) => (BEQZ cond yes no)

--- a/src/cmd/compile/internal/ssa/_gen/RISCV64latelower.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64latelower.rules
@@ -33,12 +33,11 @@
 // Bit Clear (BCLR/BCLRI)
 // Pattern: x &^ (1 << y) - clear bit y (variable shift)
 (ANDN x (SLL (MOVDconst [1]) y)) && buildcfg.GORISCV64 >= 22 => (BCLR x y)
-(ANDN x (SLLW (MOVDconst [1]) y)) && buildcfg.GORISCV64 >= 22 => (BCLR x y)
 
 // Pattern: x &^ (1 << c) - clear bit c (constant shift)
 // Always use BCLRI for constant shifts with ANDN, as ANDN is already a special instruction
 (ANDN x (SLLI [c] (MOVDconst [1]))) && c < 64 && buildcfg.GORISCV64 >= 22 => (BCLRI [c] x)
-(ANDN x (SLLIW [c] (MOVDconst [1]))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BCLRI [c] x)
+(ANDN x (SLLIW [c] (MOVDconst [1]))) && c < 31 && buildcfg.GORISCV64 >= 22 => (BCLRI [c] x)
 
 // Pattern: x & ~(1 << c) - clear bit c via AND with inverted constant
 // Note: Only convert to BCLRI if bit position >= 10, as ANDI is more efficient
@@ -54,8 +53,8 @@
 // We optimize the bit extraction part, keeping the mask for correctness
 // NOTE: This rule must come before the simpler (ANDI (SRL x y) [1]) pattern to match first
 // When mask is even (mask&1==0), the result is always 0
-(ANDI (AND (SRL x y) (MOVDconst [mask])) [1]) && (mask&1)==0 => (MOVDconst [0])
-(ANDI (AND (SRL x y) (MOVDconst [mask])) [1]) && (mask&1)==1 => (BEXT x y)
+(ANDI (AND (SRL x y) (MOVDconst [mask])) [1]) && (mask&1)==0 && buildcfg.GORISCV64 >= 22 => (MOVDconst [0])
+(ANDI (AND (SRL x y) (MOVDconst [mask])) [1]) && (mask&1)==1 && buildcfg.GORISCV64 >= 22 => (BEXT x y)
 
 // Pattern: ((x >> y) & mask) & 1 with non-constant mask (e.g., shift bound check).
 (ANDI (AND (SRL x y) mask) [1]) && buildcfg.GORISCV64 >= 22 => (AND (BEXT <typ.UInt64> x y) mask)
@@ -67,83 +66,76 @@
 (ANDI (SRLW x y) [1]) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
 (ANDI (SRLIW x [c]) [1]) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 
-// Pattern: (x >> c) & mask where mask is power of two
-// This extracts bit (c + log2(mask))
-(ANDI (SRLI x [c]) [mask]) && isUint64PowerOfTwo(mask) && c+log64(mask) < 64 && buildcfg.GORISCV64 >= 22 => (BEXTI [c+log64(mask)] x)
-(ANDI (SRLIW x [c]) [mask]) && isUint64PowerOfTwo(mask) && c+log64(mask) < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c+log64(mask)] x)
-
 // Pattern: Merge cascaded BEXTI with SRLI
 (BEXTI [c] (SRLI [d] x)) && c+d < 64 && buildcfg.GORISCV64 >= 22 => (BEXTI <typ.UInt64> [c+d] x)
 (BEXTI [c] (SRLIW [d] x)) && c+d < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI <typ.UInt64> [c+d] x)
+
+// Remove redundant SNEZ/SEQZ wrapping BEXT/BEXTI, since BEXT/BEXTI already return 0 or 1.
+(SNEZ (BEXT <t> x y)) => (BEXT x y)
+(SNEZ (BEXTI <t> [c] x)) => (BEXTI [c] x)
+(SEQZ (BEXT <t> x y)) => (XORI [1] (BEXT <t> x y))
+(SEQZ (BEXTI <t> [c] x)) => (XORI [1] (BEXTI <t> [c] x))
 
 // Pattern: x & (1 << y) with SNEZ - test if bit y is set
 // Note: SSA automatically canonicalizes commutative operations, so we only need one pattern
 // Only convert to BEXTI if bit position >= 10, as ANDI with direct immediate is more efficient
 (SNEZ (ANDI x [c])) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BEXTI [log64(c)] x)
 (SNEZ (AND x (SLL (MOVDconst [1]) y))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
-(SNEZ (AND x (SLLW (MOVDconst [1]) y))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
 (SNEZ (AND x (SLLI [c] (MOVDconst [1])))) && c < 64 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
-(SNEZ (AND x (SLLIW [c] (MOVDconst [1])))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
-(SNEZ (AND x (MOVDconst [c]))) && oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BEXTI [log64(c)] x)
+(SNEZ (AND x (SLLIW [c] (MOVDconst [1])))) && c < 31 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
+(SNEZ (AND x (MOVDconst [c]))) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BEXTI [log64(c)] x)
 
 // Pattern: 32-bit wrapped patterns for BEXT
 // Note: No boundary check on y - hardware handles it correctly
 (SNEZ (MOVWUreg (AND x (SLL (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
-(SNEZ (MOVWUreg (AND x (SLLW (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
 (SNEZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
-(SNEZ (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
+(SNEZ (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1]))))) && c < 31 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 (SNEZ (MOVWreg (AND x (SLL (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
-(SNEZ (MOVWreg (AND x (SLLW (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
 (SNEZ (MOVWreg (AND x (SLLI [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
-(SNEZ (MOVWreg (AND x (SLLIW [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
+(SNEZ (MOVWreg (AND x (SLLIW [c] (MOVDconst [1]))))) && c < 31 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 
 // Pattern: SEQZ for testing if bit is clear
 // Only convert to BEXTI if bit position >= 10, as ANDI with direct immediate is more efficient
 (SEQZ (ANDI x [c])) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [log64(c)] x))
 (SEQZ (AND x (SLL (MOVDconst [1]) y))) && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXT <typ.UInt64> x y))
-(SEQZ (AND x (SLLW (MOVDconst [1]) y))) && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXT <typ.UInt64> x y))
 (SEQZ (AND x (SLLI [c] (MOVDconst [1])))) && c < 64 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [c] x))
-(SEQZ (AND x (SLLIW [c] (MOVDconst [1])))) && c < 32 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [c] x))
-(SEQZ (AND x (MOVDconst [c]))) && oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [log64(c)] x))
+(SEQZ (AND x (SLLIW [c] (MOVDconst [1])))) && c < 31 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [c] x))
+(SEQZ (AND x (MOVDconst [c]))) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [log64(c)] x))
 
-// Pattern: Direct ANDI with shifted value (rare but possible)
-(SNEZ (ANDI (SLLI x [c]) [1])) && c > 0 && c < 64 && buildcfg.GORISCV64 >= 22 => (BEXTI [64-c] x)
-(SNEZ (ANDI (SLLIW x [c]) [1])) && c > 0 && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [32-c] x)
-(SEQZ (ANDI (SLLI x [c]) [1])) && c > 0 && c < 64 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [64-c] x))
-(SEQZ (ANDI (SLLIW x [c]) [1])) && c > 0 && c < 32 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [32-c] x))
+// Pattern: (x << c) & 1 where c > 0 is always 0
+(ANDI (SLLI x [c]) [1]) && c > 0 => (MOVDconst [0])
+(ANDI (SLLIW x [c]) [1]) && c > 0 => (MOVDconst [0])
 
 // Bit Invert (BINV/BINVI)
 // Pattern: x ^ (1 << y) - flip bit y (variable shift)
 (XOR x (SLL (MOVDconst [1]) y)) && buildcfg.GORISCV64 >= 22 => (BINV x y)
-(XOR x (SLLW (MOVDconst [1]) y)) && buildcfg.GORISCV64 >= 22 => (BINV x y)
 
 // Pattern: x ^ (1 << c) - flip bit c (constant shift)
 // Always use BINVI for constant shifts with explicit shift operations
 (XOR x (SLLI [c] (MOVDconst [1]))) && c < 64 && buildcfg.GORISCV64 >= 22 => (BINVI [c] x)
-(XOR x (SLLIW [c] (MOVDconst [1]))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BINVI [c] x)
+(XOR x (SLLIW [c] (MOVDconst [1]))) && c < 31 && buildcfg.GORISCV64 >= 22 => (BINVI [c] x)
 
 // Pattern: x ^ (1 << c) - flip bit c via XOR with constant
 // Note: Only convert to BINVI if bit position >= 10, as XORI is more efficient
 // for smaller bit positions (12-bit signed immediate can encode (1<<c) directly).
 // For c < 10: (1<<c) fits in 12-bit signed immediate, use XORI
 // For c >= 10: (1<<c) requires multiple instructions to construct, use BINVI
-(XOR x (MOVDconst [y])) && oneBit64(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22 => (BINVI [log64(y)] x)
-(XORI x [c]) && oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BINVI [log64(c)] x)
+(XOR x (MOVDconst [y])) && isUint64PowerOfTwo(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22 => (BINVI [log64(y)] x)
+(XORI x [c]) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BINVI [log64(c)] x)
 
 // Bit Set (BSET/BSETI)
 // Pattern: x | (1 << y) - set bit y (variable shift)
 (OR x (SLL (MOVDconst [1]) y)) && buildcfg.GORISCV64 >= 22 => (BSET x y)
-(OR x (SLLW (MOVDconst [1]) y)) && buildcfg.GORISCV64 >= 22 => (BSET x y)
 
 // Pattern: x | (1 << c) - set bit c (constant shift)
 // Always use BSETI for constant shifts with explicit shift operations
 (OR x (SLLI [c] (MOVDconst [1]))) && c < 64 && buildcfg.GORISCV64 >= 22 => (BSETI [c] x)
-(OR x (SLLIW [c] (MOVDconst [1]))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BSETI [c] x)
+(OR x (SLLIW [c] (MOVDconst [1]))) && c < 31 && buildcfg.GORISCV64 >= 22 => (BSETI [c] x)
 
 // Pattern: x | (1 << c) - set bit c via OR with constant
 // Note: Only convert to BSETI if bit position >= 10, as ORI is more efficient
 // for smaller bit positions (12-bit signed immediate can encode (1<<c) directly).
 // For c < 10: (1<<c) fits in 12-bit signed immediate, use ORI
 // For c >= 10: (1<<c) requires multiple instructions to construct, use BSETI
-(OR x (MOVDconst [y])) && oneBit64(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22 => (BSETI [log64(y)] x)
-(ORI x [c]) && oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BSETI [log64(c)] x)
+(OR x (MOVDconst [y])) && isUint64PowerOfTwo(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22 => (BSETI [log64(y)] x)
+(ORI x [c]) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BSETI [log64(c)] x)

--- a/src/cmd/compile/internal/ssa/_gen/RISCV64latelower.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64latelower.rules
@@ -53,6 +53,11 @@
 // The compiler inserts AND with mask to handle out-of-range shifts (e.g., y >= width)
 // We optimize the bit extraction part, keeping the mask for correctness
 // NOTE: This rule must come before the simpler (ANDI (SRL x y) [1]) pattern to match first
+// When mask is even (mask&1==0), the result is always 0
+(ANDI (AND (SRL x y) (MOVDconst [mask])) [1]) && (mask&1)==0 => (MOVDconst [0])
+(ANDI (AND (SRL x y) (MOVDconst [mask])) [1]) && (mask&1)==1 => (BEXT x y)
+
+// Pattern: ((x >> y) & mask) & 1 with non-constant mask (e.g., shift bound check).
 (ANDI (AND (SRL x y) mask) [1]) && buildcfg.GORISCV64 >= 22 => (AND (BEXT <typ.UInt64> x y) mask)
 (ANDI (AND (SRLW x y) mask) [1]) && buildcfg.GORISCV64 >= 22 => (AND (BEXT <typ.UInt64> x y) mask)
 
@@ -82,13 +87,14 @@
 (SNEZ (AND x (MOVDconst [c]))) && oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BEXTI [log64(c)] x)
 
 // Pattern: 32-bit wrapped patterns for BEXT
+// Note: No boundary check on y - hardware handles it correctly
 (SNEZ (MOVWUreg (AND x (SLL (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
 (SNEZ (MOVWUreg (AND x (SLLW (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
-(SNEZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1]))))) && c < 64 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
+(SNEZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 (SNEZ (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 (SNEZ (MOVWreg (AND x (SLL (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
 (SNEZ (MOVWreg (AND x (SLLW (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
-(SNEZ (MOVWreg (AND x (SLLI [c] (MOVDconst [1]))))) && c < 64 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
+(SNEZ (MOVWreg (AND x (SLLI [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 (SNEZ (MOVWreg (AND x (SLLIW [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 
 // Pattern: SEQZ for testing if bit is clear
@@ -101,16 +107,8 @@
 (SEQZ (AND x (MOVDconst [c]))) && oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [log64(c)] x))
 
 // Pattern: Direct ANDI with shifted value (rare but possible)
-(SNEZ (ANDI (SRL x y) [1])) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
-(SNEZ (ANDI (SRLW x y) [1])) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
-(SNEZ (ANDI (SRLI x [c]) [1])) && c < 64 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
-(SNEZ (ANDI (SRLIW x [c]) [1])) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 (SNEZ (ANDI (SLLI x [c]) [1])) && c > 0 && c < 64 && buildcfg.GORISCV64 >= 22 => (BEXTI [64-c] x)
 (SNEZ (ANDI (SLLIW x [c]) [1])) && c > 0 && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [32-c] x)
-(SEQZ (ANDI (SRL x y) [1])) && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXT <typ.UInt64> x y))
-(SEQZ (ANDI (SRLW x y) [1])) && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXT <typ.UInt64> x y))
-(SEQZ (ANDI (SRLI x [c]) [1])) && c < 64 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [c] x))
-(SEQZ (ANDI (SRLIW x [c]) [1])) && c < 32 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [c] x))
 (SEQZ (ANDI (SLLI x [c]) [1])) && c > 0 && c < 64 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [64-c] x))
 (SEQZ (ANDI (SLLIW x [c]) [1])) && c > 0 && c < 32 && buildcfg.GORISCV64 >= 22 => (SEQZ (BEXTI <typ.UInt64> [32-c] x))
 

--- a/src/cmd/compile/internal/ssa/_gen/RISCV64latelower.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64latelower.rules
@@ -86,13 +86,13 @@
 (SNEZ (AND x (MOVDconst [c]))) && isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22 => (BEXTI [log64(c)] x)
 
 // Pattern: 32-bit wrapped patterns for BEXT
-// Note: No boundary check on y - hardware handles it correctly
-(SNEZ (MOVWUreg (AND x (SLL (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
 (SNEZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 (SNEZ (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1]))))) && c < 31 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
-(SNEZ (MOVWreg (AND x (SLL (MOVDconst [1]) y)))) && buildcfg.GORISCV64 >= 22 => (BEXT x y)
 (SNEZ (MOVWreg (AND x (SLLI [c] (MOVDconst [1]))))) && c < 32 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
 (SNEZ (MOVWreg (AND x (SLLIW [c] (MOVDconst [1]))))) && c < 31 && buildcfg.GORISCV64 >= 22 => (BEXTI [c] x)
+// ANDI [c]-guarded variable shift: c <= 31 guarantees y & c < 32, so BEXT is safe.
+(SNEZ (MOVWUreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y))))) && c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22 => (BEXT x (ANDI <typ.UInt64> [c] y))
+(SNEZ (MOVWreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y))))) && c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22 => (BEXT x (ANDI <typ.UInt64> [c] y))
 
 // Pattern: SEQZ for testing if bit is clear
 // Only convert to BEXTI if bit position >= 10, as ANDI with direct immediate is more efficient

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64.go
@@ -10407,64 +10407,6 @@ func rewriteBlockRISCV64(b *Block) bool {
 			}
 			break
 		}
-		// match: (BEQZ (MOVWUreg (AND x (SLL (MOVDconst [1]) y))) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BEQZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWUreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64AND {
-				break
-			}
-			_ = v_0_0.Args[1]
-			v_0_0_0 := v_0_0.Args[0]
-			v_0_0_1 := v_0_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-				x := v_0_0_0
-				if v_0_0_1.Op != OpRISCV64SLL {
-					continue
-				}
-				y := v_0_0_1.Args[1]
-				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BEQZ, v0)
-				return true
-			}
-			break
-		}
-		// match: (BEQZ (MOVWreg (AND x (SLL (MOVDconst [1]) y))) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BEQZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64AND {
-				break
-			}
-			_ = v_0_0.Args[1]
-			v_0_0_0 := v_0_0.Args[0]
-			v_0_0_1 := v_0_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-				x := v_0_0_0
-				if v_0_0_1.Op != OpRISCV64SLL {
-					continue
-				}
-				y := v_0_0_1.Args[1]
-				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BEQZ, v0)
-				return true
-			}
-			break
-		}
 		// match: (BEQZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))) yes no)
 		// cond: c < 32 && buildcfg.GORISCV64 >= 22
 		// result: (BEQZ (BEXTI <typ.UInt64> [c] x) yes no)
@@ -10580,6 +10522,88 @@ func rewriteBlockRISCV64(b *Block) bool {
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
 				v0.AuxInt = int64ToAuxInt(c)
 				v0.AddArg(x)
+				b.resetWithControl(BlockRISCV64BEQZ, v0)
+				return true
+			}
+			break
+		}
+		// match: (BEQZ (MOVWUreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y)))) yes no)
+		// cond: c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22
+		// result: (BEQZ (BEXT <typ.UInt64> x (ANDI <typ.UInt64> [c] y)) yes no)
+		for b.Controls[0].Op == OpRISCV64MOVWUreg {
+			v_0 := b.Controls[0]
+			v_0_0 := v_0.Args[0]
+			if v_0_0.Op != OpRISCV64AND {
+				break
+			}
+			_ = v_0_0.Args[1]
+			v_0_0_0 := v_0_0.Args[0]
+			v_0_0_1 := v_0_0.Args[1]
+			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
+				x := v_0_0_0
+				if v_0_0_1.Op != OpRISCV64SLL {
+					continue
+				}
+				_ = v_0_0_1.Args[1]
+				v_0_0_1_0 := v_0_0_1.Args[0]
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 {
+					continue
+				}
+				v_0_0_1_1 := v_0_0_1.Args[1]
+				if v_0_0_1_1.Op != OpRISCV64ANDI {
+					continue
+				}
+				c := auxIntToInt64(v_0_0_1_1.AuxInt)
+				y := v_0_0_1_1.Args[0]
+				if !(c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22) {
+					continue
+				}
+				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
+				v1 := b.NewValue0(v_0.Pos, OpRISCV64ANDI, typ.UInt64)
+				v1.AuxInt = int64ToAuxInt(c)
+				v1.AddArg(y)
+				v0.AddArg2(x, v1)
+				b.resetWithControl(BlockRISCV64BEQZ, v0)
+				return true
+			}
+			break
+		}
+		// match: (BEQZ (MOVWreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y)))) yes no)
+		// cond: c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22
+		// result: (BEQZ (BEXT <typ.UInt64> x (ANDI <typ.UInt64> [c] y)) yes no)
+		for b.Controls[0].Op == OpRISCV64MOVWreg {
+			v_0 := b.Controls[0]
+			v_0_0 := v_0.Args[0]
+			if v_0_0.Op != OpRISCV64AND {
+				break
+			}
+			_ = v_0_0.Args[1]
+			v_0_0_0 := v_0_0.Args[0]
+			v_0_0_1 := v_0_0.Args[1]
+			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
+				x := v_0_0_0
+				if v_0_0_1.Op != OpRISCV64SLL {
+					continue
+				}
+				_ = v_0_0_1.Args[1]
+				v_0_0_1_0 := v_0_0_1.Args[0]
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 {
+					continue
+				}
+				v_0_0_1_1 := v_0_0_1.Args[1]
+				if v_0_0_1_1.Op != OpRISCV64ANDI {
+					continue
+				}
+				c := auxIntToInt64(v_0_0_1_1.AuxInt)
+				y := v_0_0_1_1.Args[0]
+				if !(c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22) {
+					continue
+				}
+				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
+				v1 := b.NewValue0(v_0.Pos, OpRISCV64ANDI, typ.UInt64)
+				v1.AuxInt = int64ToAuxInt(c)
+				v1.AddArg(y)
+				v0.AddArg2(x, v1)
 				b.resetWithControl(BlockRISCV64BEQZ, v0)
 				return true
 			}
@@ -11209,64 +11233,6 @@ func rewriteBlockRISCV64(b *Block) bool {
 			}
 			break
 		}
-		// match: (BNEZ (MOVWUreg (AND x (SLL (MOVDconst [1]) y))) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BNEZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWUreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64AND {
-				break
-			}
-			_ = v_0_0.Args[1]
-			v_0_0_0 := v_0_0.Args[0]
-			v_0_0_1 := v_0_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-				x := v_0_0_0
-				if v_0_0_1.Op != OpRISCV64SLL {
-					continue
-				}
-				y := v_0_0_1.Args[1]
-				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BNEZ, v0)
-				return true
-			}
-			break
-		}
-		// match: (BNEZ (MOVWreg (AND x (SLL (MOVDconst [1]) y))) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BNEZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64AND {
-				break
-			}
-			_ = v_0_0.Args[1]
-			v_0_0_0 := v_0_0.Args[0]
-			v_0_0_1 := v_0_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-				x := v_0_0_0
-				if v_0_0_1.Op != OpRISCV64SLL {
-					continue
-				}
-				y := v_0_0_1.Args[1]
-				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BNEZ, v0)
-				return true
-			}
-			break
-		}
 		// match: (BNEZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))) yes no)
 		// cond: c < 32 && buildcfg.GORISCV64 >= 22
 		// result: (BNEZ (BEXTI <typ.UInt64> [c] x) yes no)
@@ -11382,6 +11348,88 @@ func rewriteBlockRISCV64(b *Block) bool {
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
 				v0.AuxInt = int64ToAuxInt(c)
 				v0.AddArg(x)
+				b.resetWithControl(BlockRISCV64BNEZ, v0)
+				return true
+			}
+			break
+		}
+		// match: (BNEZ (MOVWUreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y)))) yes no)
+		// cond: c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22
+		// result: (BNEZ (BEXT <typ.UInt64> x (ANDI <typ.UInt64> [c] y)) yes no)
+		for b.Controls[0].Op == OpRISCV64MOVWUreg {
+			v_0 := b.Controls[0]
+			v_0_0 := v_0.Args[0]
+			if v_0_0.Op != OpRISCV64AND {
+				break
+			}
+			_ = v_0_0.Args[1]
+			v_0_0_0 := v_0_0.Args[0]
+			v_0_0_1 := v_0_0.Args[1]
+			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
+				x := v_0_0_0
+				if v_0_0_1.Op != OpRISCV64SLL {
+					continue
+				}
+				_ = v_0_0_1.Args[1]
+				v_0_0_1_0 := v_0_0_1.Args[0]
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 {
+					continue
+				}
+				v_0_0_1_1 := v_0_0_1.Args[1]
+				if v_0_0_1_1.Op != OpRISCV64ANDI {
+					continue
+				}
+				c := auxIntToInt64(v_0_0_1_1.AuxInt)
+				y := v_0_0_1_1.Args[0]
+				if !(c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22) {
+					continue
+				}
+				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
+				v1 := b.NewValue0(v_0.Pos, OpRISCV64ANDI, typ.UInt64)
+				v1.AuxInt = int64ToAuxInt(c)
+				v1.AddArg(y)
+				v0.AddArg2(x, v1)
+				b.resetWithControl(BlockRISCV64BNEZ, v0)
+				return true
+			}
+			break
+		}
+		// match: (BNEZ (MOVWreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y)))) yes no)
+		// cond: c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22
+		// result: (BNEZ (BEXT <typ.UInt64> x (ANDI <typ.UInt64> [c] y)) yes no)
+		for b.Controls[0].Op == OpRISCV64MOVWreg {
+			v_0 := b.Controls[0]
+			v_0_0 := v_0.Args[0]
+			if v_0_0.Op != OpRISCV64AND {
+				break
+			}
+			_ = v_0_0.Args[1]
+			v_0_0_0 := v_0_0.Args[0]
+			v_0_0_1 := v_0_0.Args[1]
+			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
+				x := v_0_0_0
+				if v_0_0_1.Op != OpRISCV64SLL {
+					continue
+				}
+				_ = v_0_0_1.Args[1]
+				v_0_0_1_0 := v_0_0_1.Args[0]
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 {
+					continue
+				}
+				v_0_0_1_1 := v_0_0_1.Args[1]
+				if v_0_0_1_1.Op != OpRISCV64ANDI {
+					continue
+				}
+				c := auxIntToInt64(v_0_0_1_1.AuxInt)
+				y := v_0_0_1_1.Args[0]
+				if !(c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22) {
+					continue
+				}
+				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
+				v1 := b.NewValue0(v_0.Pos, OpRISCV64ANDI, typ.UInt64)
+				v1.AuxInt = int64ToAuxInt(c)
+				v1.AddArg(y)
+				v0.AddArg2(x, v1)
 				b.resetWithControl(BlockRISCV64BNEZ, v0)
 				return true
 			}

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64.go
@@ -6583,7 +6583,7 @@ func rewriteValueRISCV64_OpRISCV64OR(v *Value) bool {
 	b := v.Block
 	typ := &b.Func.Config.Types
 	// match: (OR (MOVDconst [c]) x)
-	// cond: oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
+	// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (BSETI [log64(c)] x)
 	for {
 		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
@@ -6592,7 +6592,7 @@ func rewriteValueRISCV64_OpRISCV64OR(v *Value) bool {
 			}
 			c := auxIntToInt64(v_0.AuxInt)
 			x := v_1
-			if !(oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
+			if !(isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BSETI)
@@ -8099,7 +8099,7 @@ func rewriteValueRISCV64_OpRISCV64XOR(v *Value) bool {
 	v_1 := v.Args[1]
 	v_0 := v.Args[0]
 	// match: (XOR (MOVDconst [c]) x)
-	// cond: oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
+	// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (BINVI [log64(c)] x)
 	for {
 		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
@@ -8108,7 +8108,7 @@ func rewriteValueRISCV64_OpRISCV64XOR(v *Value) bool {
 			}
 			c := auxIntToInt64(v_0.AuxInt)
 			x := v_1
-			if !(oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
+			if !(isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BINVI)
@@ -10306,7 +10306,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			return true
 		}
 		// match: (BEQZ (AND x (MOVDconst [c])) yes no)
-		// cond: oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
+		// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 		// result: (BEQZ (BEXTI <typ.UInt64> [log64(c)] x) yes no)
 		for b.Controls[0].Op == OpRISCV64AND {
 			v_0 := b.Controls[0]
@@ -10319,7 +10319,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 					continue
 				}
 				c := auxIntToInt64(v_0_1.AuxInt)
-				if !(oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
+				if !(isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -10341,31 +10341,6 @@ func rewriteBlockRISCV64(b *Block) bool {
 			for _i0 := 0; _i0 <= 1; _i0, v_0_0, v_0_1 = _i0+1, v_0_1, v_0_0 {
 				x := v_0_0
 				if v_0_1.Op != OpRISCV64SLL {
-					continue
-				}
-				y := v_0_1.Args[1]
-				v_0_1_0 := v_0_1.Args[0]
-				if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BEQZ, v0)
-				return true
-			}
-			break
-		}
-		// match: (BEQZ (AND x (SLLW (MOVDconst [1]) y)) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BEQZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64AND {
-			v_0 := b.Controls[0]
-			_ = v_0.Args[1]
-			v_0_0 := v_0.Args[0]
-			v_0_1 := v_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0, v_0_1 = _i0+1, v_0_1, v_0_0 {
-				x := v_0_0
-				if v_0_1.Op != OpRISCV64SLLW {
 					continue
 				}
 				y := v_0_1.Args[1]
@@ -10407,7 +10382,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BEQZ (AND x (SLLIW [c] (MOVDconst [1]))) yes no)
-		// cond: c < 32 && buildcfg.GORISCV64 >= 22
+		// cond: c < 31 && buildcfg.GORISCV64 >= 22
 		// result: (BEQZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64AND {
 			v_0 := b.Controls[0]
@@ -10421,7 +10396,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_1.AuxInt)
 				v_0_1_0 := v_0_1.Args[0]
-				if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+				if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -10461,35 +10436,6 @@ func rewriteBlockRISCV64(b *Block) bool {
 			}
 			break
 		}
-		// match: (BEQZ (MOVWUreg (AND x (SLLW (MOVDconst [1]) y))) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BEQZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWUreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64AND {
-				break
-			}
-			_ = v_0_0.Args[1]
-			v_0_0_0 := v_0_0.Args[0]
-			v_0_0_1 := v_0_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-				x := v_0_0_0
-				if v_0_0_1.Op != OpRISCV64SLLW {
-					continue
-				}
-				y := v_0_0_1.Args[1]
-				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BEQZ, v0)
-				return true
-			}
-			break
-		}
 		// match: (BEQZ (MOVWreg (AND x (SLL (MOVDconst [1]) y))) yes no)
 		// cond: buildcfg.GORISCV64 >= 22
 		// result: (BEQZ (BEXT <typ.UInt64> x y) yes no)
@@ -10505,35 +10451,6 @@ func rewriteBlockRISCV64(b *Block) bool {
 			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
 				x := v_0_0_0
 				if v_0_0_1.Op != OpRISCV64SLL {
-					continue
-				}
-				y := v_0_0_1.Args[1]
-				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BEQZ, v0)
-				return true
-			}
-			break
-		}
-		// match: (BEQZ (MOVWreg (AND x (SLLW (MOVDconst [1]) y))) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BEQZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64AND {
-				break
-			}
-			_ = v_0_0.Args[1]
-			v_0_0_0 := v_0_0.Args[0]
-			v_0_0_1 := v_0_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-				x := v_0_0_0
-				if v_0_0_1.Op != OpRISCV64SLLW {
 					continue
 				}
 				y := v_0_0_1.Args[1]
@@ -10579,7 +10496,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BEQZ (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no)
-		// cond: c < 32 && buildcfg.GORISCV64 >= 22
+		// cond: c < 31 && buildcfg.GORISCV64 >= 22
 		// result: (BEQZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWUreg {
 			v_0 := b.Controls[0]
@@ -10597,7 +10514,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_0_1.AuxInt)
 				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -10639,7 +10556,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BEQZ (MOVWreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no)
-		// cond: c < 32 && buildcfg.GORISCV64 >= 22
+		// cond: c < 31 && buildcfg.GORISCV64 >= 22
 		// result: (BEQZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWreg {
 			v_0 := b.Controls[0]
@@ -10657,7 +10574,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_0_1.AuxInt)
 				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -10853,8 +10770,8 @@ func rewriteBlockRISCV64(b *Block) bool {
 			return true
 		}
 		// match: (BEQZ (ANDI [1] (SLLI [c] x)) yes no)
-		// cond: c > 0 && c < 64 && buildcfg.GORISCV64 >= 22
-		// result: (BEQZ (BEXTI <typ.UInt64> [64-c] x) yes no)
+		// cond: c > 0
+		// result: (BEQZ (MOVDconst [0]) yes no)
 		for b.Controls[0].Op == OpRISCV64ANDI {
 			v_0 := b.Controls[0]
 			if auxIntToInt64(v_0.AuxInt) != 1 {
@@ -10865,19 +10782,17 @@ func rewriteBlockRISCV64(b *Block) bool {
 				break
 			}
 			c := auxIntToInt64(v_0_0.AuxInt)
-			x := v_0_0.Args[0]
-			if !(c > 0 && c < 64 && buildcfg.GORISCV64 >= 22) {
+			if !(c > 0) {
 				break
 			}
-			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
-			v0.AuxInt = int64ToAuxInt(64 - c)
-			v0.AddArg(x)
+			v0 := b.NewValue0(v_0.Pos, OpRISCV64MOVDconst, typ.UInt64)
+			v0.AuxInt = int64ToAuxInt(0)
 			b.resetWithControl(BlockRISCV64BEQZ, v0)
 			return true
 		}
 		// match: (BEQZ (ANDI [1] (SLLIW [c] x)) yes no)
-		// cond: c > 0 && c < 32 && buildcfg.GORISCV64 >= 22
-		// result: (BEQZ (BEXTI <typ.UInt64> [32-c] x) yes no)
+		// cond: c > 0
+		// result: (BEQZ (MOVDconst [0]) yes no)
 		for b.Controls[0].Op == OpRISCV64ANDI {
 			v_0 := b.Controls[0]
 			if auxIntToInt64(v_0.AuxInt) != 1 {
@@ -10888,13 +10803,11 @@ func rewriteBlockRISCV64(b *Block) bool {
 				break
 			}
 			c := auxIntToInt64(v_0_0.AuxInt)
-			x := v_0_0.Args[0]
-			if !(c > 0 && c < 32 && buildcfg.GORISCV64 >= 22) {
+			if !(c > 0) {
 				break
 			}
-			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
-			v0.AuxInt = int64ToAuxInt(32 - c)
-			v0.AddArg(x)
+			v0 := b.NewValue0(v_0.Pos, OpRISCV64MOVDconst, typ.UInt64)
+			v0.AuxInt = int64ToAuxInt(0)
 			b.resetWithControl(BlockRISCV64BEQZ, v0)
 			return true
 		}
@@ -11195,7 +11108,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			return true
 		}
 		// match: (BNEZ (AND x (MOVDconst [c])) yes no)
-		// cond: oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
+		// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 		// result: (BNEZ (BEXTI <typ.UInt64> [log64(c)] x) yes no)
 		for b.Controls[0].Op == OpRISCV64AND {
 			v_0 := b.Controls[0]
@@ -11208,7 +11121,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 					continue
 				}
 				c := auxIntToInt64(v_0_1.AuxInt)
-				if !(oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
+				if !(isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -11230,31 +11143,6 @@ func rewriteBlockRISCV64(b *Block) bool {
 			for _i0 := 0; _i0 <= 1; _i0, v_0_0, v_0_1 = _i0+1, v_0_1, v_0_0 {
 				x := v_0_0
 				if v_0_1.Op != OpRISCV64SLL {
-					continue
-				}
-				y := v_0_1.Args[1]
-				v_0_1_0 := v_0_1.Args[0]
-				if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BNEZ, v0)
-				return true
-			}
-			break
-		}
-		// match: (BNEZ (AND x (SLLW (MOVDconst [1]) y)) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BNEZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64AND {
-			v_0 := b.Controls[0]
-			_ = v_0.Args[1]
-			v_0_0 := v_0.Args[0]
-			v_0_1 := v_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0, v_0_1 = _i0+1, v_0_1, v_0_0 {
-				x := v_0_0
-				if v_0_1.Op != OpRISCV64SLLW {
 					continue
 				}
 				y := v_0_1.Args[1]
@@ -11296,7 +11184,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BNEZ (AND x (SLLIW [c] (MOVDconst [1]))) yes no)
-		// cond: c < 32 && buildcfg.GORISCV64 >= 22
+		// cond: c < 31 && buildcfg.GORISCV64 >= 22
 		// result: (BNEZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64AND {
 			v_0 := b.Controls[0]
@@ -11310,7 +11198,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_1.AuxInt)
 				v_0_1_0 := v_0_1.Args[0]
-				if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+				if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -11350,35 +11238,6 @@ func rewriteBlockRISCV64(b *Block) bool {
 			}
 			break
 		}
-		// match: (BNEZ (MOVWUreg (AND x (SLLW (MOVDconst [1]) y))) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BNEZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWUreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64AND {
-				break
-			}
-			_ = v_0_0.Args[1]
-			v_0_0_0 := v_0_0.Args[0]
-			v_0_0_1 := v_0_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-				x := v_0_0_0
-				if v_0_0_1.Op != OpRISCV64SLLW {
-					continue
-				}
-				y := v_0_0_1.Args[1]
-				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BNEZ, v0)
-				return true
-			}
-			break
-		}
 		// match: (BNEZ (MOVWreg (AND x (SLL (MOVDconst [1]) y))) yes no)
 		// cond: buildcfg.GORISCV64 >= 22
 		// result: (BNEZ (BEXT <typ.UInt64> x y) yes no)
@@ -11394,35 +11253,6 @@ func rewriteBlockRISCV64(b *Block) bool {
 			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
 				x := v_0_0_0
 				if v_0_0_1.Op != OpRISCV64SLL {
-					continue
-				}
-				y := v_0_0_1.Args[1]
-				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-					continue
-				}
-				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXT, typ.UInt64)
-				v0.AddArg2(x, y)
-				b.resetWithControl(BlockRISCV64BNEZ, v0)
-				return true
-			}
-			break
-		}
-		// match: (BNEZ (MOVWreg (AND x (SLLW (MOVDconst [1]) y))) yes no)
-		// cond: buildcfg.GORISCV64 >= 22
-		// result: (BNEZ (BEXT <typ.UInt64> x y) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64AND {
-				break
-			}
-			_ = v_0_0.Args[1]
-			v_0_0_0 := v_0_0.Args[0]
-			v_0_0_1 := v_0_0.Args[1]
-			for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-				x := v_0_0_0
-				if v_0_0_1.Op != OpRISCV64SLLW {
 					continue
 				}
 				y := v_0_0_1.Args[1]
@@ -11468,7 +11298,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BNEZ (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no)
-		// cond: c < 32 && buildcfg.GORISCV64 >= 22
+		// cond: c < 31 && buildcfg.GORISCV64 >= 22
 		// result: (BNEZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWUreg {
 			v_0 := b.Controls[0]
@@ -11486,7 +11316,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_0_1.AuxInt)
 				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -11528,7 +11358,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BNEZ (MOVWreg (AND x (SLLIW [c] (MOVDconst [1])))) yes no)
-		// cond: c < 32 && buildcfg.GORISCV64 >= 22
+		// cond: c < 31 && buildcfg.GORISCV64 >= 22
 		// result: (BNEZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWreg {
 			v_0 := b.Controls[0]
@@ -11546,7 +11376,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_0_1.AuxInt)
 				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -11742,8 +11572,8 @@ func rewriteBlockRISCV64(b *Block) bool {
 			return true
 		}
 		// match: (BNEZ (ANDI [1] (SLLI [c] x)) yes no)
-		// cond: c > 0 && c < 64 && buildcfg.GORISCV64 >= 22
-		// result: (BNEZ (BEXTI <typ.UInt64> [64-c] x) yes no)
+		// cond: c > 0
+		// result: (BNEZ (MOVDconst [0]) yes no)
 		for b.Controls[0].Op == OpRISCV64ANDI {
 			v_0 := b.Controls[0]
 			if auxIntToInt64(v_0.AuxInt) != 1 {
@@ -11754,19 +11584,17 @@ func rewriteBlockRISCV64(b *Block) bool {
 				break
 			}
 			c := auxIntToInt64(v_0_0.AuxInt)
-			x := v_0_0.Args[0]
-			if !(c > 0 && c < 64 && buildcfg.GORISCV64 >= 22) {
+			if !(c > 0) {
 				break
 			}
-			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
-			v0.AuxInt = int64ToAuxInt(64 - c)
-			v0.AddArg(x)
+			v0 := b.NewValue0(v_0.Pos, OpRISCV64MOVDconst, typ.UInt64)
+			v0.AuxInt = int64ToAuxInt(0)
 			b.resetWithControl(BlockRISCV64BNEZ, v0)
 			return true
 		}
 		// match: (BNEZ (ANDI [1] (SLLIW [c] x)) yes no)
-		// cond: c > 0 && c < 32 && buildcfg.GORISCV64 >= 22
-		// result: (BNEZ (BEXTI <typ.UInt64> [32-c] x) yes no)
+		// cond: c > 0
+		// result: (BNEZ (MOVDconst [0]) yes no)
 		for b.Controls[0].Op == OpRISCV64ANDI {
 			v_0 := b.Controls[0]
 			if auxIntToInt64(v_0.AuxInt) != 1 {
@@ -11777,13 +11605,11 @@ func rewriteBlockRISCV64(b *Block) bool {
 				break
 			}
 			c := auxIntToInt64(v_0_0.AuxInt)
-			x := v_0_0.Args[0]
-			if !(c > 0 && c < 32 && buildcfg.GORISCV64 >= 22) {
+			if !(c > 0) {
 				break
 			}
-			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
-			v0.AuxInt = int64ToAuxInt(32 - c)
-			v0.AddArg(x)
+			v0 := b.NewValue0(v_0.Pos, OpRISCV64MOVDconst, typ.UInt64)
+			v0.AuxInt = int64ToAuxInt(0)
 			b.resetWithControl(BlockRISCV64BNEZ, v0)
 			return true
 		}

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64.go
@@ -10549,7 +10549,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BEQZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))) yes no)
-		// cond: c < 64 && buildcfg.GORISCV64 >= 22
+		// cond: c < 32 && buildcfg.GORISCV64 >= 22
 		// result: (BEQZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWUreg {
 			v_0 := b.Controls[0]
@@ -10567,7 +10567,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_0_1.AuxInt)
 				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 64 && buildcfg.GORISCV64 >= 22) {
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -10609,7 +10609,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BEQZ (MOVWreg (AND x (SLLI [c] (MOVDconst [1])))) yes no)
-		// cond: c < 64 && buildcfg.GORISCV64 >= 22
+		// cond: c < 32 && buildcfg.GORISCV64 >= 22
 		// result: (BEQZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWreg {
 			v_0 := b.Controls[0]
@@ -10627,7 +10627,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_0_1.AuxInt)
 				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 64 && buildcfg.GORISCV64 >= 22) {
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -10758,28 +10758,8 @@ func rewriteBlockRISCV64(b *Block) bool {
 			b.resetWithControl(BlockRISCV64BEQZ, v0)
 			return true
 		}
-		// match: (BEQZ (MOVWUreg (SRLIW [c] x)) yes no)
-		// cond: c < 32 && buildcfg.GORISCV64 >= 22
-		// result: (BEQZ (BEXTI <typ.UInt64> [c] x) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWUreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64SRLIW {
-				break
-			}
-			c := auxIntToInt64(v_0_0.AuxInt)
-			x := v_0_0.Args[0]
-			if !(c < 32 && buildcfg.GORISCV64 >= 22) {
-				break
-			}
-			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
-			v0.AuxInt = int64ToAuxInt(c)
-			v0.AddArg(x)
-			b.resetWithControl(BlockRISCV64BEQZ, v0)
-			return true
-		}
 		// match: (BEQZ (MOVWUreg (ANDI [1] (SRLI [c] x))) yes no)
-		// cond: c < 64 && buildcfg.GORISCV64 >= 22
+		// cond: c < 32 && buildcfg.GORISCV64 >= 22
 		// result: (BEQZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWUreg {
 			v_0 := b.Controls[0]
@@ -10793,7 +10773,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			}
 			c := auxIntToInt64(v_0_0_0.AuxInt)
 			x := v_0_0_0.Args[0]
-			if !(c < 64 && buildcfg.GORISCV64 >= 22) {
+			if !(c < 32 && buildcfg.GORISCV64 >= 22) {
 				break
 			}
 			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -10990,6 +10970,25 @@ func rewriteBlockRISCV64(b *Block) bool {
 			}
 			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
 			v0.AuxInt = int64ToAuxInt(63)
+			v0.AddArg(x)
+			b.resetWithControl(BlockRISCV64BEQZ, v0)
+			return true
+		}
+		// match: (BEQZ (MOVWUreg (SRLIW [31] x)) yes no)
+		// cond: buildcfg.GORISCV64 >= 22
+		// result: (BEQZ (BEXTI <typ.UInt64> [31] x) yes no)
+		for b.Controls[0].Op == OpRISCV64MOVWUreg {
+			v_0 := b.Controls[0]
+			v_0_0 := v_0.Args[0]
+			if v_0_0.Op != OpRISCV64SRLIW || auxIntToInt64(v_0_0.AuxInt) != 31 {
+				break
+			}
+			x := v_0_0.Args[0]
+			if !(buildcfg.GORISCV64 >= 22) {
+				break
+			}
+			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
+			v0.AuxInt = int64ToAuxInt(31)
 			v0.AddArg(x)
 			b.resetWithControl(BlockRISCV64BEQZ, v0)
 			return true
@@ -11439,7 +11438,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BNEZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))) yes no)
-		// cond: c < 64 && buildcfg.GORISCV64 >= 22
+		// cond: c < 32 && buildcfg.GORISCV64 >= 22
 		// result: (BNEZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWUreg {
 			v_0 := b.Controls[0]
@@ -11457,7 +11456,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_0_1.AuxInt)
 				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 64 && buildcfg.GORISCV64 >= 22) {
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -11499,7 +11498,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			break
 		}
 		// match: (BNEZ (MOVWreg (AND x (SLLI [c] (MOVDconst [1])))) yes no)
-		// cond: c < 64 && buildcfg.GORISCV64 >= 22
+		// cond: c < 32 && buildcfg.GORISCV64 >= 22
 		// result: (BNEZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWreg {
 			v_0 := b.Controls[0]
@@ -11517,7 +11516,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 				}
 				c := auxIntToInt64(v_0_0_1.AuxInt)
 				v_0_0_1_0 := v_0_0_1.Args[0]
-				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 64 && buildcfg.GORISCV64 >= 22) {
+				if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
 					continue
 				}
 				v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -11648,28 +11647,8 @@ func rewriteBlockRISCV64(b *Block) bool {
 			b.resetWithControl(BlockRISCV64BNEZ, v0)
 			return true
 		}
-		// match: (BNEZ (MOVWUreg (SRLIW [c] x)) yes no)
-		// cond: c < 32 && buildcfg.GORISCV64 >= 22
-		// result: (BNEZ (BEXTI <typ.UInt64> [c] x) yes no)
-		for b.Controls[0].Op == OpRISCV64MOVWUreg {
-			v_0 := b.Controls[0]
-			v_0_0 := v_0.Args[0]
-			if v_0_0.Op != OpRISCV64SRLIW {
-				break
-			}
-			c := auxIntToInt64(v_0_0.AuxInt)
-			x := v_0_0.Args[0]
-			if !(c < 32 && buildcfg.GORISCV64 >= 22) {
-				break
-			}
-			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
-			v0.AuxInt = int64ToAuxInt(c)
-			v0.AddArg(x)
-			b.resetWithControl(BlockRISCV64BNEZ, v0)
-			return true
-		}
 		// match: (BNEZ (MOVWUreg (ANDI [1] (SRLI [c] x))) yes no)
-		// cond: c < 64 && buildcfg.GORISCV64 >= 22
+		// cond: c < 32 && buildcfg.GORISCV64 >= 22
 		// result: (BNEZ (BEXTI <typ.UInt64> [c] x) yes no)
 		for b.Controls[0].Op == OpRISCV64MOVWUreg {
 			v_0 := b.Controls[0]
@@ -11683,7 +11662,7 @@ func rewriteBlockRISCV64(b *Block) bool {
 			}
 			c := auxIntToInt64(v_0_0_0.AuxInt)
 			x := v_0_0_0.Args[0]
-			if !(c < 64 && buildcfg.GORISCV64 >= 22) {
+			if !(c < 32 && buildcfg.GORISCV64 >= 22) {
 				break
 			}
 			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
@@ -11880,6 +11859,25 @@ func rewriteBlockRISCV64(b *Block) bool {
 			}
 			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
 			v0.AuxInt = int64ToAuxInt(63)
+			v0.AddArg(x)
+			b.resetWithControl(BlockRISCV64BNEZ, v0)
+			return true
+		}
+		// match: (BNEZ (MOVWUreg (SRLIW [31] x)) yes no)
+		// cond: buildcfg.GORISCV64 >= 22
+		// result: (BNEZ (BEXTI <typ.UInt64> [31] x) yes no)
+		for b.Controls[0].Op == OpRISCV64MOVWUreg {
+			v_0 := b.Controls[0]
+			v_0_0 := v_0.Args[0]
+			if v_0_0.Op != OpRISCV64SRLIW || auxIntToInt64(v_0_0.AuxInt) != 31 {
+				break
+			}
+			x := v_0_0.Args[0]
+			if !(buildcfg.GORISCV64 >= 22) {
+				break
+			}
+			v0 := b.NewValue0(v_0.Pos, OpRISCV64BEXTI, typ.UInt64)
+			v0.AuxInt = int64ToAuxInt(31)
 			v0.AddArg(x)
 			b.resetWithControl(BlockRISCV64BNEZ, v0)
 			return true

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64latelower.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64latelower.go
@@ -160,7 +160,7 @@ func rewriteValueRISCV64latelower_OpRISCV64ANDI(v *Value) bool {
 		return true
 	}
 	// match: (ANDI (AND (SRL x y) (MOVDconst [mask])) [1])
-	// cond: (mask&1)==0
+	// cond: (mask&1)==0 && buildcfg.GORISCV64 >= 22
 	// result: (MOVDconst [0])
 	for {
 		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpRISCV64AND {
@@ -177,7 +177,7 @@ func rewriteValueRISCV64latelower_OpRISCV64ANDI(v *Value) bool {
 				continue
 			}
 			mask := auxIntToInt64(v_0_1.AuxInt)
-			if !((mask & 1) == 0) {
+			if !((mask&1) == 0 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64MOVDconst)
@@ -187,7 +187,7 @@ func rewriteValueRISCV64latelower_OpRISCV64ANDI(v *Value) bool {
 		break
 	}
 	// match: (ANDI (AND (SRL x y) (MOVDconst [mask])) [1])
-	// cond: (mask&1)==1
+	// cond: (mask&1)==1 && buildcfg.GORISCV64 >= 22
 	// result: (BEXT x y)
 	for {
 		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpRISCV64AND {
@@ -206,7 +206,7 @@ func rewriteValueRISCV64latelower_OpRISCV64ANDI(v *Value) bool {
 				continue
 			}
 			mask := auxIntToInt64(v_0_1.AuxInt)
-			if !((mask & 1) == 1) {
+			if !((mask&1) == 1 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BEXT)
@@ -337,40 +337,34 @@ func rewriteValueRISCV64latelower_OpRISCV64ANDI(v *Value) bool {
 		v.AddArg(x)
 		return true
 	}
-	// match: (ANDI (SRLI x [c]) [mask])
-	// cond: isUint64PowerOfTwo(mask) && c+log64(mask) < 64 && buildcfg.GORISCV64 >= 22
-	// result: (BEXTI [c+log64(mask)] x)
+	// match: (ANDI (SLLI x [c]) [1])
+	// cond: c > 0
+	// result: (MOVDconst [0])
 	for {
-		mask := auxIntToInt64(v.AuxInt)
-		if v_0.Op != OpRISCV64SRLI {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpRISCV64SLLI {
 			break
 		}
 		c := auxIntToInt64(v_0.AuxInt)
-		x := v_0.Args[0]
-		if !(isUint64PowerOfTwo(mask) && c+log64(mask) < 64 && buildcfg.GORISCV64 >= 22) {
+		if !(c > 0) {
 			break
 		}
-		v.reset(OpRISCV64BEXTI)
-		v.AuxInt = int64ToAuxInt(c + log64(mask))
-		v.AddArg(x)
+		v.reset(OpRISCV64MOVDconst)
+		v.AuxInt = int64ToAuxInt(0)
 		return true
 	}
-	// match: (ANDI (SRLIW x [c]) [mask])
-	// cond: isUint64PowerOfTwo(mask) && c+log64(mask) < 32 && buildcfg.GORISCV64 >= 22
-	// result: (BEXTI [c+log64(mask)] x)
+	// match: (ANDI (SLLIW x [c]) [1])
+	// cond: c > 0
+	// result: (MOVDconst [0])
 	for {
-		mask := auxIntToInt64(v.AuxInt)
-		if v_0.Op != OpRISCV64SRLIW {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpRISCV64SLLIW {
 			break
 		}
 		c := auxIntToInt64(v_0.AuxInt)
-		x := v_0.Args[0]
-		if !(isUint64PowerOfTwo(mask) && c+log64(mask) < 32 && buildcfg.GORISCV64 >= 22) {
+		if !(c > 0) {
 			break
 		}
-		v.reset(OpRISCV64BEXTI)
-		v.AuxInt = int64ToAuxInt(c + log64(mask))
-		v.AddArg(x)
+		v.reset(OpRISCV64MOVDconst)
+		v.AuxInt = int64ToAuxInt(0)
 		return true
 	}
 	return false
@@ -384,23 +378,6 @@ func rewriteValueRISCV64latelower_OpRISCV64ANDN(v *Value) bool {
 	for {
 		x := v_0
 		if v_1.Op != OpRISCV64SLL {
-			break
-		}
-		y := v_1.Args[1]
-		v_1_0 := v_1.Args[0]
-		if v_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64BCLR)
-		v.AddArg2(x, y)
-		return true
-	}
-	// match: (ANDN x (SLLW (MOVDconst [1]) y))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BCLR x y)
-	for {
-		x := v_0
-		if v_1.Op != OpRISCV64SLLW {
 			break
 		}
 		y := v_1.Args[1]
@@ -431,7 +408,7 @@ func rewriteValueRISCV64latelower_OpRISCV64ANDN(v *Value) bool {
 		return true
 	}
 	// match: (ANDN x (SLLIW [c] (MOVDconst [1])))
-	// cond: c < 32 && buildcfg.GORISCV64 >= 22
+	// cond: c < 31 && buildcfg.GORISCV64 >= 22
 	// result: (BCLRI [c] x)
 	for {
 		x := v_0
@@ -440,7 +417,7 @@ func rewriteValueRISCV64latelower_OpRISCV64ANDN(v *Value) bool {
 		}
 		c := auxIntToInt64(v_1.AuxInt)
 		v_1_0 := v_1.Args[0]
-		if v_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+		if v_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 			break
 		}
 		v.reset(OpRISCV64BCLRI)
@@ -548,26 +525,6 @@ func rewriteValueRISCV64latelower_OpRISCV64OR(v *Value) bool {
 		}
 		break
 	}
-	// match: (OR x (SLLW (MOVDconst [1]) y))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BSET x y)
-	for {
-		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
-			x := v_0
-			if v_1.Op != OpRISCV64SLLW {
-				continue
-			}
-			y := v_1.Args[1]
-			v_1_0 := v_1.Args[0]
-			if v_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-				continue
-			}
-			v.reset(OpRISCV64BSET)
-			v.AddArg2(x, y)
-			return true
-		}
-		break
-	}
 	// match: (OR x (SLLI [c] (MOVDconst [1])))
 	// cond: c < 64 && buildcfg.GORISCV64 >= 22
 	// result: (BSETI [c] x)
@@ -590,7 +547,7 @@ func rewriteValueRISCV64latelower_OpRISCV64OR(v *Value) bool {
 		break
 	}
 	// match: (OR x (SLLIW [c] (MOVDconst [1])))
-	// cond: c < 32 && buildcfg.GORISCV64 >= 22
+	// cond: c < 31 && buildcfg.GORISCV64 >= 22
 	// result: (BSETI [c] x)
 	for {
 		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
@@ -600,7 +557,7 @@ func rewriteValueRISCV64latelower_OpRISCV64OR(v *Value) bool {
 			}
 			c := auxIntToInt64(v_1.AuxInt)
 			v_1_0 := v_1.Args[0]
-			if v_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+			if v_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BSETI)
@@ -611,7 +568,7 @@ func rewriteValueRISCV64latelower_OpRISCV64OR(v *Value) bool {
 		break
 	}
 	// match: (OR x (MOVDconst [y]))
-	// cond: oneBit64(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22
+	// cond: isUint64PowerOfTwo(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (BSETI [log64(y)] x)
 	for {
 		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
@@ -620,7 +577,7 @@ func rewriteValueRISCV64latelower_OpRISCV64OR(v *Value) bool {
 				continue
 			}
 			y := auxIntToInt64(v_1.AuxInt)
-			if !(oneBit64(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22) {
+			if !(isUint64PowerOfTwo(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BSETI)
@@ -635,12 +592,12 @@ func rewriteValueRISCV64latelower_OpRISCV64OR(v *Value) bool {
 func rewriteValueRISCV64latelower_OpRISCV64ORI(v *Value) bool {
 	v_0 := v.Args[0]
 	// match: (ORI x [c])
-	// cond: oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
+	// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (BSETI [log64(c)] x)
 	for {
 		c := auxIntToInt64(v.AuxInt)
 		x := v_0
-		if !(oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
+		if !(isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
 			break
 		}
 		v.reset(OpRISCV64BSETI)
@@ -654,6 +611,39 @@ func rewriteValueRISCV64latelower_OpRISCV64SEQZ(v *Value) bool {
 	v_0 := v.Args[0]
 	b := v.Block
 	typ := &b.Func.Config.Types
+	// match: (SEQZ (BEXT <t> x y))
+	// result: (XORI [1] (BEXT <t> x y))
+	for {
+		if v_0.Op != OpRISCV64BEXT {
+			break
+		}
+		t := v_0.Type
+		y := v_0.Args[1]
+		x := v_0.Args[0]
+		v.reset(OpRISCV64XORI)
+		v.AuxInt = int64ToAuxInt(1)
+		v0 := b.NewValue0(v.Pos, OpRISCV64BEXT, t)
+		v0.AddArg2(x, y)
+		v.AddArg(v0)
+		return true
+	}
+	// match: (SEQZ (BEXTI <t> [c] x))
+	// result: (XORI [1] (BEXTI <t> [c] x))
+	for {
+		if v_0.Op != OpRISCV64BEXTI {
+			break
+		}
+		t := v_0.Type
+		c := auxIntToInt64(v_0.AuxInt)
+		x := v_0.Args[0]
+		v.reset(OpRISCV64XORI)
+		v.AuxInt = int64ToAuxInt(1)
+		v0 := b.NewValue0(v.Pos, OpRISCV64BEXTI, t)
+		v0.AuxInt = int64ToAuxInt(c)
+		v0.AddArg(x)
+		v.AddArg(v0)
+		return true
+	}
 	// match: (SEQZ (ANDI x [c]))
 	// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (SEQZ (BEXTI <typ.UInt64> [log64(c)] x))
@@ -701,34 +691,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SEQZ(v *Value) bool {
 		}
 		break
 	}
-	// match: (SEQZ (AND x (SLLW (MOVDconst [1]) y)))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (SEQZ (BEXT <typ.UInt64> x y))
-	for {
-		if v_0.Op != OpRISCV64AND {
-			break
-		}
-		_ = v_0.Args[1]
-		v_0_0 := v_0.Args[0]
-		v_0_1 := v_0.Args[1]
-		for _i0 := 0; _i0 <= 1; _i0, v_0_0, v_0_1 = _i0+1, v_0_1, v_0_0 {
-			x := v_0_0
-			if v_0_1.Op != OpRISCV64SLLW {
-				continue
-			}
-			y := v_0_1.Args[1]
-			v_0_1_0 := v_0_1.Args[0]
-			if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-				continue
-			}
-			v.reset(OpRISCV64SEQZ)
-			v0 := b.NewValue0(v.Pos, OpRISCV64BEXT, typ.UInt64)
-			v0.AddArg2(x, y)
-			v.AddArg(v0)
-			return true
-		}
-		break
-	}
 	// match: (SEQZ (AND x (SLLI [c] (MOVDconst [1]))))
 	// cond: c < 64 && buildcfg.GORISCV64 >= 22
 	// result: (SEQZ (BEXTI <typ.UInt64> [c] x))
@@ -759,7 +721,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SEQZ(v *Value) bool {
 		break
 	}
 	// match: (SEQZ (AND x (SLLIW [c] (MOVDconst [1]))))
-	// cond: c < 32 && buildcfg.GORISCV64 >= 22
+	// cond: c < 31 && buildcfg.GORISCV64 >= 22
 	// result: (SEQZ (BEXTI <typ.UInt64> [c] x))
 	for {
 		if v_0.Op != OpRISCV64AND {
@@ -775,7 +737,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SEQZ(v *Value) bool {
 			}
 			c := auxIntToInt64(v_0_1.AuxInt)
 			v_0_1_0 := v_0_1.Args[0]
-			if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+			if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64SEQZ)
@@ -788,7 +750,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SEQZ(v *Value) bool {
 		break
 	}
 	// match: (SEQZ (AND x (MOVDconst [c])))
-	// cond: oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
+	// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (SEQZ (BEXTI <typ.UInt64> [log64(c)] x))
 	for {
 		if v_0.Op != OpRISCV64AND {
@@ -803,7 +765,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SEQZ(v *Value) bool {
 				continue
 			}
 			c := auxIntToInt64(v_0_1.AuxInt)
-			if !(oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
+			if !(isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64SEQZ)
@@ -814,52 +776,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SEQZ(v *Value) bool {
 			return true
 		}
 		break
-	}
-	// match: (SEQZ (ANDI (SLLI x [c]) [1]))
-	// cond: c > 0 && c < 64 && buildcfg.GORISCV64 >= 22
-	// result: (SEQZ (BEXTI <typ.UInt64> [64-c] x))
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SLLI {
-			break
-		}
-		c := auxIntToInt64(v_0_0.AuxInt)
-		x := v_0_0.Args[0]
-		if !(c > 0 && c < 64 && buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64SEQZ)
-		v0 := b.NewValue0(v.Pos, OpRISCV64BEXTI, typ.UInt64)
-		v0.AuxInt = int64ToAuxInt(64 - c)
-		v0.AddArg(x)
-		v.AddArg(v0)
-		return true
-	}
-	// match: (SEQZ (ANDI (SLLIW x [c]) [1]))
-	// cond: c > 0 && c < 32 && buildcfg.GORISCV64 >= 22
-	// result: (SEQZ (BEXTI <typ.UInt64> [32-c] x))
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SLLIW {
-			break
-		}
-		c := auxIntToInt64(v_0_0.AuxInt)
-		x := v_0_0.Args[0]
-		if !(c > 0 && c < 32 && buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64SEQZ)
-		v0 := b.NewValue0(v.Pos, OpRISCV64BEXTI, typ.UInt64)
-		v0.AuxInt = int64ToAuxInt(32 - c)
-		v0.AddArg(x)
-		v.AddArg(v0)
-		return true
 	}
 	return false
 }
@@ -941,6 +857,31 @@ func rewriteValueRISCV64latelower_OpRISCV64SLLI(v *Value) bool {
 }
 func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 	v_0 := v.Args[0]
+	// match: (SNEZ (BEXT <t> x y))
+	// result: (BEXT x y)
+	for {
+		if v_0.Op != OpRISCV64BEXT {
+			break
+		}
+		y := v_0.Args[1]
+		x := v_0.Args[0]
+		v.reset(OpRISCV64BEXT)
+		v.AddArg2(x, y)
+		return true
+	}
+	// match: (SNEZ (BEXTI <t> [c] x))
+	// result: (BEXTI [c] x)
+	for {
+		if v_0.Op != OpRISCV64BEXTI {
+			break
+		}
+		c := auxIntToInt64(v_0.AuxInt)
+		x := v_0.Args[0]
+		v.reset(OpRISCV64BEXTI)
+		v.AuxInt = int64ToAuxInt(c)
+		v.AddArg(x)
+		return true
+	}
 	// match: (SNEZ (ANDI x [c]))
 	// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [log64(c)] x)
@@ -984,32 +925,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		}
 		break
 	}
-	// match: (SNEZ (AND x (SLLW (MOVDconst [1]) y)))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BEXT x y)
-	for {
-		if v_0.Op != OpRISCV64AND {
-			break
-		}
-		_ = v_0.Args[1]
-		v_0_0 := v_0.Args[0]
-		v_0_1 := v_0.Args[1]
-		for _i0 := 0; _i0 <= 1; _i0, v_0_0, v_0_1 = _i0+1, v_0_1, v_0_0 {
-			x := v_0_0
-			if v_0_1.Op != OpRISCV64SLLW {
-				continue
-			}
-			y := v_0_1.Args[1]
-			v_0_1_0 := v_0_1.Args[0]
-			if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-				continue
-			}
-			v.reset(OpRISCV64BEXT)
-			v.AddArg2(x, y)
-			return true
-		}
-		break
-	}
 	// match: (SNEZ (AND x (SLLI [c] (MOVDconst [1]))))
 	// cond: c < 64 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [c] x)
@@ -1038,7 +953,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		break
 	}
 	// match: (SNEZ (AND x (SLLIW [c] (MOVDconst [1]))))
-	// cond: c < 32 && buildcfg.GORISCV64 >= 22
+	// cond: c < 31 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [c] x)
 	for {
 		if v_0.Op != OpRISCV64AND {
@@ -1054,7 +969,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 			}
 			c := auxIntToInt64(v_0_1.AuxInt)
 			v_0_1_0 := v_0_1.Args[0]
-			if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+			if v_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BEXTI)
@@ -1065,7 +980,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		break
 	}
 	// match: (SNEZ (AND x (MOVDconst [c])))
-	// cond: oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
+	// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [log64(c)] x)
 	for {
 		if v_0.Op != OpRISCV64AND {
@@ -1080,7 +995,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 				continue
 			}
 			c := auxIntToInt64(v_0_1.AuxInt)
-			if !(oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
+			if !(isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BEXTI)
@@ -1107,36 +1022,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
 			x := v_0_0_0
 			if v_0_0_1.Op != OpRISCV64SLL {
-				continue
-			}
-			y := v_0_0_1.Args[1]
-			v_0_0_1_0 := v_0_0_1.Args[0]
-			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-				continue
-			}
-			v.reset(OpRISCV64BEXT)
-			v.AddArg2(x, y)
-			return true
-		}
-		break
-	}
-	// match: (SNEZ (MOVWUreg (AND x (SLLW (MOVDconst [1]) y))))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BEXT x y)
-	for {
-		if v_0.Op != OpRISCV64MOVWUreg {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64AND {
-			break
-		}
-		_ = v_0_0.Args[1]
-		v_0_0_0 := v_0_0.Args[0]
-		v_0_0_1 := v_0_0.Args[1]
-		for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-			x := v_0_0_0
-			if v_0_0_1.Op != OpRISCV64SLLW {
 				continue
 			}
 			y := v_0_0_1.Args[1]
@@ -1182,7 +1067,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		break
 	}
 	// match: (SNEZ (MOVWUreg (AND x (SLLIW [c] (MOVDconst [1])))))
-	// cond: c < 32 && buildcfg.GORISCV64 >= 22
+	// cond: c < 31 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [c] x)
 	for {
 		if v_0.Op != OpRISCV64MOVWUreg {
@@ -1202,7 +1087,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 			}
 			c := auxIntToInt64(v_0_0_1.AuxInt)
 			v_0_0_1_0 := v_0_0_1.Args[0]
-			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BEXTI)
@@ -1229,36 +1114,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
 			x := v_0_0_0
 			if v_0_0_1.Op != OpRISCV64SLL {
-				continue
-			}
-			y := v_0_0_1.Args[1]
-			v_0_0_1_0 := v_0_0_1.Args[0]
-			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-				continue
-			}
-			v.reset(OpRISCV64BEXT)
-			v.AddArg2(x, y)
-			return true
-		}
-		break
-	}
-	// match: (SNEZ (MOVWreg (AND x (SLLW (MOVDconst [1]) y))))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BEXT x y)
-	for {
-		if v_0.Op != OpRISCV64MOVWreg {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64AND {
-			break
-		}
-		_ = v_0_0.Args[1]
-		v_0_0_0 := v_0_0.Args[0]
-		v_0_0_1 := v_0_0.Args[1]
-		for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-			x := v_0_0_0
-			if v_0_0_1.Op != OpRISCV64SLLW {
 				continue
 			}
 			y := v_0_0_1.Args[1]
@@ -1304,7 +1159,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		break
 	}
 	// match: (SNEZ (MOVWreg (AND x (SLLIW [c] (MOVDconst [1])))))
-	// cond: c < 32 && buildcfg.GORISCV64 >= 22
+	// cond: c < 31 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [c] x)
 	for {
 		if v_0.Op != OpRISCV64MOVWreg {
@@ -1324,7 +1179,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 			}
 			c := auxIntToInt64(v_0_0_1.AuxInt)
 			v_0_0_1_0 := v_0_0_1.Args[0]
-			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BEXTI)
@@ -1333,48 +1188,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 			return true
 		}
 		break
-	}
-	// match: (SNEZ (ANDI (SLLI x [c]) [1]))
-	// cond: c > 0 && c < 64 && buildcfg.GORISCV64 >= 22
-	// result: (BEXTI [64-c] x)
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SLLI {
-			break
-		}
-		c := auxIntToInt64(v_0_0.AuxInt)
-		x := v_0_0.Args[0]
-		if !(c > 0 && c < 64 && buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64BEXTI)
-		v.AuxInt = int64ToAuxInt(64 - c)
-		v.AddArg(x)
-		return true
-	}
-	// match: (SNEZ (ANDI (SLLIW x [c]) [1]))
-	// cond: c > 0 && c < 32 && buildcfg.GORISCV64 >= 22
-	// result: (BEXTI [32-c] x)
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SLLIW {
-			break
-		}
-		c := auxIntToInt64(v_0_0.AuxInt)
-		x := v_0_0.Args[0]
-		if !(c > 0 && c < 32 && buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64BEXTI)
-		v.AuxInt = int64ToAuxInt(32 - c)
-		v.AddArg(x)
-		return true
 	}
 	return false
 }
@@ -1568,26 +1381,6 @@ func rewriteValueRISCV64latelower_OpRISCV64XOR(v *Value) bool {
 		}
 		break
 	}
-	// match: (XOR x (SLLW (MOVDconst [1]) y))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BINV x y)
-	for {
-		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
-			x := v_0
-			if v_1.Op != OpRISCV64SLLW {
-				continue
-			}
-			y := v_1.Args[1]
-			v_1_0 := v_1.Args[0]
-			if v_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-				continue
-			}
-			v.reset(OpRISCV64BINV)
-			v.AddArg2(x, y)
-			return true
-		}
-		break
-	}
 	// match: (XOR x (SLLI [c] (MOVDconst [1])))
 	// cond: c < 64 && buildcfg.GORISCV64 >= 22
 	// result: (BINVI [c] x)
@@ -1610,7 +1403,7 @@ func rewriteValueRISCV64latelower_OpRISCV64XOR(v *Value) bool {
 		break
 	}
 	// match: (XOR x (SLLIW [c] (MOVDconst [1])))
-	// cond: c < 32 && buildcfg.GORISCV64 >= 22
+	// cond: c < 31 && buildcfg.GORISCV64 >= 22
 	// result: (BINVI [c] x)
 	for {
 		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
@@ -1620,7 +1413,7 @@ func rewriteValueRISCV64latelower_OpRISCV64XOR(v *Value) bool {
 			}
 			c := auxIntToInt64(v_1.AuxInt)
 			v_1_0 := v_1.Args[0]
-			if v_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
+			if v_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1_0.AuxInt) != 1 || !(c < 31 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BINVI)
@@ -1631,7 +1424,7 @@ func rewriteValueRISCV64latelower_OpRISCV64XOR(v *Value) bool {
 		break
 	}
 	// match: (XOR x (MOVDconst [y]))
-	// cond: oneBit64(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22
+	// cond: isUint64PowerOfTwo(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (BINVI [log64(y)] x)
 	for {
 		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
@@ -1640,7 +1433,7 @@ func rewriteValueRISCV64latelower_OpRISCV64XOR(v *Value) bool {
 				continue
 			}
 			y := auxIntToInt64(v_1.AuxInt)
-			if !(oneBit64(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22) {
+			if !(isUint64PowerOfTwo(y) && log64(y) >= 10 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BINVI)
@@ -1655,12 +1448,12 @@ func rewriteValueRISCV64latelower_OpRISCV64XOR(v *Value) bool {
 func rewriteValueRISCV64latelower_OpRISCV64XORI(v *Value) bool {
 	v_0 := v.Args[0]
 	// match: (XORI x [c])
-	// cond: oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
+	// cond: isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22
 	// result: (BINVI [log64(c)] x)
 	for {
 		c := auxIntToInt64(v.AuxInt)
 		x := v_0
-		if !(oneBit64(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
+		if !(isUint64PowerOfTwo(c) && log64(c) >= 10 && buildcfg.GORISCV64 >= 22) {
 			break
 		}
 		v.reset(OpRISCV64BINVI)

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64latelower.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64latelower.go
@@ -159,6 +159,62 @@ func rewriteValueRISCV64latelower_OpRISCV64ANDI(v *Value) bool {
 		v.AddArg(x)
 		return true
 	}
+	// match: (ANDI (AND (SRL x y) (MOVDconst [mask])) [1])
+	// cond: (mask&1)==0
+	// result: (MOVDconst [0])
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpRISCV64AND {
+			break
+		}
+		_ = v_0.Args[1]
+		v_0_0 := v_0.Args[0]
+		v_0_1 := v_0.Args[1]
+		for _i0 := 0; _i0 <= 1; _i0, v_0_0, v_0_1 = _i0+1, v_0_1, v_0_0 {
+			if v_0_0.Op != OpRISCV64SRL {
+				continue
+			}
+			if v_0_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			mask := auxIntToInt64(v_0_1.AuxInt)
+			if !((mask & 1) == 0) {
+				continue
+			}
+			v.reset(OpRISCV64MOVDconst)
+			v.AuxInt = int64ToAuxInt(0)
+			return true
+		}
+		break
+	}
+	// match: (ANDI (AND (SRL x y) (MOVDconst [mask])) [1])
+	// cond: (mask&1)==1
+	// result: (BEXT x y)
+	for {
+		if auxIntToInt64(v.AuxInt) != 1 || v_0.Op != OpRISCV64AND {
+			break
+		}
+		_ = v_0.Args[1]
+		v_0_0 := v_0.Args[0]
+		v_0_1 := v_0.Args[1]
+		for _i0 := 0; _i0 <= 1; _i0, v_0_0, v_0_1 = _i0+1, v_0_1, v_0_0 {
+			if v_0_0.Op != OpRISCV64SRL {
+				continue
+			}
+			y := v_0_0.Args[1]
+			x := v_0_0.Args[0]
+			if v_0_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			mask := auxIntToInt64(v_0_1.AuxInt)
+			if !((mask & 1) == 1) {
+				continue
+			}
+			v.reset(OpRISCV64BEXT)
+			v.AddArg2(x, y)
+			return true
+		}
+		break
+	}
 	// match: (ANDI (AND (SRL x y) mask) [1])
 	// cond: buildcfg.GORISCV64 >= 22
 	// result: (AND (BEXT <typ.UInt64> x y) mask)
@@ -759,96 +815,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SEQZ(v *Value) bool {
 		}
 		break
 	}
-	// match: (SEQZ (ANDI (SRL x y) [1]))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (SEQZ (BEXT <typ.UInt64> x y))
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SRL {
-			break
-		}
-		y := v_0_0.Args[1]
-		x := v_0_0.Args[0]
-		if !(buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64SEQZ)
-		v0 := b.NewValue0(v.Pos, OpRISCV64BEXT, typ.UInt64)
-		v0.AddArg2(x, y)
-		v.AddArg(v0)
-		return true
-	}
-	// match: (SEQZ (ANDI (SRLW x y) [1]))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (SEQZ (BEXT <typ.UInt64> x y))
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SRLW {
-			break
-		}
-		y := v_0_0.Args[1]
-		x := v_0_0.Args[0]
-		if !(buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64SEQZ)
-		v0 := b.NewValue0(v.Pos, OpRISCV64BEXT, typ.UInt64)
-		v0.AddArg2(x, y)
-		v.AddArg(v0)
-		return true
-	}
-	// match: (SEQZ (ANDI (SRLI x [c]) [1]))
-	// cond: c < 64 && buildcfg.GORISCV64 >= 22
-	// result: (SEQZ (BEXTI <typ.UInt64> [c] x))
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SRLI {
-			break
-		}
-		c := auxIntToInt64(v_0_0.AuxInt)
-		x := v_0_0.Args[0]
-		if !(c < 64 && buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64SEQZ)
-		v0 := b.NewValue0(v.Pos, OpRISCV64BEXTI, typ.UInt64)
-		v0.AuxInt = int64ToAuxInt(c)
-		v0.AddArg(x)
-		v.AddArg(v0)
-		return true
-	}
-	// match: (SEQZ (ANDI (SRLIW x [c]) [1]))
-	// cond: c < 32 && buildcfg.GORISCV64 >= 22
-	// result: (SEQZ (BEXTI <typ.UInt64> [c] x))
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SRLIW {
-			break
-		}
-		c := auxIntToInt64(v_0_0.AuxInt)
-		x := v_0_0.Args[0]
-		if !(c < 32 && buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64SEQZ)
-		v0 := b.NewValue0(v.Pos, OpRISCV64BEXTI, typ.UInt64)
-		v0.AuxInt = int64ToAuxInt(c)
-		v0.AddArg(x)
-		v.AddArg(v0)
-		return true
-	}
 	// match: (SEQZ (ANDI (SLLI x [c]) [1]))
 	// cond: c > 0 && c < 64 && buildcfg.GORISCV64 >= 22
 	// result: (SEQZ (BEXTI <typ.UInt64> [64-c] x))
@@ -1185,7 +1151,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		break
 	}
 	// match: (SNEZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))))
-	// cond: c < 64 && buildcfg.GORISCV64 >= 22
+	// cond: c < 32 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [c] x)
 	for {
 		if v_0.Op != OpRISCV64MOVWUreg {
@@ -1205,7 +1171,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 			}
 			c := auxIntToInt64(v_0_0_1.AuxInt)
 			v_0_0_1_0 := v_0_0_1.Args[0]
-			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 64 && buildcfg.GORISCV64 >= 22) {
+			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BEXTI)
@@ -1307,7 +1273,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		break
 	}
 	// match: (SNEZ (MOVWreg (AND x (SLLI [c] (MOVDconst [1])))))
-	// cond: c < 64 && buildcfg.GORISCV64 >= 22
+	// cond: c < 32 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [c] x)
 	for {
 		if v_0.Op != OpRISCV64MOVWreg {
@@ -1327,7 +1293,7 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 			}
 			c := auxIntToInt64(v_0_0_1.AuxInt)
 			v_0_0_1_0 := v_0_0_1.Args[0]
-			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 64 && buildcfg.GORISCV64 >= 22) {
+			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(c < 32 && buildcfg.GORISCV64 >= 22) {
 				continue
 			}
 			v.reset(OpRISCV64BEXTI)
@@ -1367,88 +1333,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 			return true
 		}
 		break
-	}
-	// match: (SNEZ (ANDI (SRL x y) [1]))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BEXT x y)
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SRL {
-			break
-		}
-		y := v_0_0.Args[1]
-		x := v_0_0.Args[0]
-		if !(buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64BEXT)
-		v.AddArg2(x, y)
-		return true
-	}
-	// match: (SNEZ (ANDI (SRLW x y) [1]))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BEXT x y)
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SRLW {
-			break
-		}
-		y := v_0_0.Args[1]
-		x := v_0_0.Args[0]
-		if !(buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64BEXT)
-		v.AddArg2(x, y)
-		return true
-	}
-	// match: (SNEZ (ANDI (SRLI x [c]) [1]))
-	// cond: c < 64 && buildcfg.GORISCV64 >= 22
-	// result: (BEXTI [c] x)
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SRLI {
-			break
-		}
-		c := auxIntToInt64(v_0_0.AuxInt)
-		x := v_0_0.Args[0]
-		if !(c < 64 && buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64BEXTI)
-		v.AuxInt = int64ToAuxInt(c)
-		v.AddArg(x)
-		return true
-	}
-	// match: (SNEZ (ANDI (SRLIW x [c]) [1]))
-	// cond: c < 32 && buildcfg.GORISCV64 >= 22
-	// result: (BEXTI [c] x)
-	for {
-		if v_0.Op != OpRISCV64ANDI || auxIntToInt64(v_0.AuxInt) != 1 {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64SRLIW {
-			break
-		}
-		c := auxIntToInt64(v_0_0.AuxInt)
-		x := v_0_0.Args[0]
-		if !(c < 32 && buildcfg.GORISCV64 >= 22) {
-			break
-		}
-		v.reset(OpRISCV64BEXTI)
-		v.AuxInt = int64ToAuxInt(c)
-		v.AddArg(x)
-		return true
 	}
 	// match: (SNEZ (ANDI (SLLI x [c]) [1]))
 	// cond: c > 0 && c < 64 && buildcfg.GORISCV64 >= 22

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64latelower.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64latelower.go
@@ -857,6 +857,8 @@ func rewriteValueRISCV64latelower_OpRISCV64SLLI(v *Value) bool {
 }
 func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 	v_0 := v.Args[0]
+	b := v.Block
+	typ := &b.Func.Config.Types
 	// match: (SNEZ (BEXT <t> x y))
 	// result: (BEXT x y)
 	for {
@@ -1005,36 +1007,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		}
 		break
 	}
-	// match: (SNEZ (MOVWUreg (AND x (SLL (MOVDconst [1]) y))))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BEXT x y)
-	for {
-		if v_0.Op != OpRISCV64MOVWUreg {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64AND {
-			break
-		}
-		_ = v_0_0.Args[1]
-		v_0_0_0 := v_0_0.Args[0]
-		v_0_0_1 := v_0_0.Args[1]
-		for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-			x := v_0_0_0
-			if v_0_0_1.Op != OpRISCV64SLL {
-				continue
-			}
-			y := v_0_0_1.Args[1]
-			v_0_0_1_0 := v_0_0_1.Args[0]
-			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-				continue
-			}
-			v.reset(OpRISCV64BEXT)
-			v.AddArg2(x, y)
-			return true
-		}
-		break
-	}
 	// match: (SNEZ (MOVWUreg (AND x (SLLI [c] (MOVDconst [1])))))
 	// cond: c < 32 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [c] x)
@@ -1097,36 +1069,6 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 		}
 		break
 	}
-	// match: (SNEZ (MOVWreg (AND x (SLL (MOVDconst [1]) y))))
-	// cond: buildcfg.GORISCV64 >= 22
-	// result: (BEXT x y)
-	for {
-		if v_0.Op != OpRISCV64MOVWreg {
-			break
-		}
-		v_0_0 := v_0.Args[0]
-		if v_0_0.Op != OpRISCV64AND {
-			break
-		}
-		_ = v_0_0.Args[1]
-		v_0_0_0 := v_0_0.Args[0]
-		v_0_0_1 := v_0_0.Args[1]
-		for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
-			x := v_0_0_0
-			if v_0_0_1.Op != OpRISCV64SLL {
-				continue
-			}
-			y := v_0_0_1.Args[1]
-			v_0_0_1_0 := v_0_0_1.Args[0]
-			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 || !(buildcfg.GORISCV64 >= 22) {
-				continue
-			}
-			v.reset(OpRISCV64BEXT)
-			v.AddArg2(x, y)
-			return true
-		}
-		break
-	}
 	// match: (SNEZ (MOVWreg (AND x (SLLI [c] (MOVDconst [1])))))
 	// cond: c < 32 && buildcfg.GORISCV64 >= 22
 	// result: (BEXTI [c] x)
@@ -1185,6 +1127,90 @@ func rewriteValueRISCV64latelower_OpRISCV64SNEZ(v *Value) bool {
 			v.reset(OpRISCV64BEXTI)
 			v.AuxInt = int64ToAuxInt(c)
 			v.AddArg(x)
+			return true
+		}
+		break
+	}
+	// match: (SNEZ (MOVWUreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y)))))
+	// cond: c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22
+	// result: (BEXT x (ANDI <typ.UInt64> [c] y))
+	for {
+		if v_0.Op != OpRISCV64MOVWUreg {
+			break
+		}
+		v_0_0 := v_0.Args[0]
+		if v_0_0.Op != OpRISCV64AND {
+			break
+		}
+		_ = v_0_0.Args[1]
+		v_0_0_0 := v_0_0.Args[0]
+		v_0_0_1 := v_0_0.Args[1]
+		for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
+			x := v_0_0_0
+			if v_0_0_1.Op != OpRISCV64SLL {
+				continue
+			}
+			_ = v_0_0_1.Args[1]
+			v_0_0_1_0 := v_0_0_1.Args[0]
+			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 {
+				continue
+			}
+			v_0_0_1_1 := v_0_0_1.Args[1]
+			if v_0_0_1_1.Op != OpRISCV64ANDI {
+				continue
+			}
+			c := auxIntToInt64(v_0_0_1_1.AuxInt)
+			y := v_0_0_1_1.Args[0]
+			if !(c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64BEXT)
+			v0 := b.NewValue0(v.Pos, OpRISCV64ANDI, typ.UInt64)
+			v0.AuxInt = int64ToAuxInt(c)
+			v0.AddArg(y)
+			v.AddArg2(x, v0)
+			return true
+		}
+		break
+	}
+	// match: (SNEZ (MOVWreg (AND x (SLL (MOVDconst [1]) (ANDI [c] y)))))
+	// cond: c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22
+	// result: (BEXT x (ANDI <typ.UInt64> [c] y))
+	for {
+		if v_0.Op != OpRISCV64MOVWreg {
+			break
+		}
+		v_0_0 := v_0.Args[0]
+		if v_0_0.Op != OpRISCV64AND {
+			break
+		}
+		_ = v_0_0.Args[1]
+		v_0_0_0 := v_0_0.Args[0]
+		v_0_0_1 := v_0_0.Args[1]
+		for _i0 := 0; _i0 <= 1; _i0, v_0_0_0, v_0_0_1 = _i0+1, v_0_0_1, v_0_0_0 {
+			x := v_0_0_0
+			if v_0_0_1.Op != OpRISCV64SLL {
+				continue
+			}
+			_ = v_0_0_1.Args[1]
+			v_0_0_1_0 := v_0_0_1.Args[0]
+			if v_0_0_1_0.Op != OpRISCV64MOVDconst || auxIntToInt64(v_0_0_1_0.AuxInt) != 1 {
+				continue
+			}
+			v_0_0_1_1 := v_0_0_1.Args[1]
+			if v_0_0_1_1.Op != OpRISCV64ANDI {
+				continue
+			}
+			c := auxIntToInt64(v_0_0_1_1.AuxInt)
+			y := v_0_0_1_1.Args[0]
+			if !(c >= 0 && c <= 31 && buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64BEXT)
+			v0 := b.NewValue0(v.Pos, OpRISCV64ANDI, typ.UInt64)
+			v0.AuxInt = int64ToAuxInt(c)
+			v0.AddArg(y)
+			v.AddArg2(x, v0)
 			return true
 		}
 		break

--- a/test/codegen/bits.go
+++ b/test/codegen/bits.go
@@ -447,6 +447,128 @@ func issue44228b(a []int32, i int) bool {
 	return a[i>>5]&(1<<(i&31)) != 0
 }
 
+// RISCV64 Zbs threshold: bit 0-9 → ANDI/ORI/XORI (fits 12-bit signed immediate),
+// bit >=10 → BEXTI/BSETI/BINVI (immediate requires multiple instructions).
+
+func bitcheckThresholdBEXTI(a uint64) int {
+	//  riscv64/rva22u64,riscv64/rva23u64:"ANDI\t[$]512"
+	if a&(1<<9) != 0 {
+		return 1
+	}
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXTI\t[$]10"
+	if a&(1<<10) != 0 {
+		return 1
+	}
+	return 0
+}
+
+func bitonThreshold(a, b uint64) (uint64, uint64) {
+	//  riscv64/rva22u64,riscv64/rva23u64:"ORI\t[$]512"
+	a |= 1 << 9
+	//  riscv64/rva22u64,riscv64/rva23u64:"BSETI\t[$]10"
+	b |= 1 << 10
+	return a, b
+}
+
+func bitcomplThreshold(a, b uint64) (uint64, uint64) {
+	//  riscv64/rva22u64,riscv64/rva23u64:"XORI\t[$]512"
+	a ^= 1 << 9
+	//  riscv64/rva22u64,riscv64/rva23u64:"BINVI\t[$]10"
+	b ^= 1 << 10
+	return a, b
+}
+
+func bitoffThreshold(a, b uint64) (uint64, uint64) {
+	//  riscv64/rva22u64,riscv64/rva23u64:"ANDI"
+	a &= ^(uint64(1) << 9)
+	//  riscv64/rva22u64,riscv64/rva23u64:"BCLRI\t[$]11"
+	b &= ^(uint64(1) << 11)
+	return a, b
+}
+
+func bitcheckShiftMask(a uint64) int {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXTI\t[$]5"
+	if (a>>3)&4 != 0 {
+		return 1
+	}
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXTI\t[$]12"
+	if (a>>10)&4 != 0 {
+		return 1
+	}
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXTI\t[$]16"
+	if (a>>12)&16 != 0 {
+		return 1
+	}
+	return 0
+}
+
+func bitBEXTValue(a, b uint64) uint64 {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXT"
+	return (a >> b) & 1
+}
+
+func bitBEXTValue32(a, b uint32) uint32 {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXT"
+	return (a >> b) & 1
+}
+
+func bitcheck32Boundary(a uint32) int {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXTI\t[$]30"
+	if a&(1<<30) != 0 {
+		return 1
+	}
+	return 0
+}
+
+// (x<<c)&1 is always 0 when c>0 (left shift fills low bits with zero).
+func bitcheckLeftShiftAnd1(a uint64) int {
+	//  riscv64/rva22u64,riscv64/rva23u64:-"SLLI"
+	if (a<<3)&1 != 0 {
+		return 1
+	}
+	return 0
+}
+
+// ((x>>y)&const)&1 with odd constant mask → BEXT.
+func bitcheckMaskedShift(a, b uint64) int {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXT"
+	if ((a >> b) & 3) & 1 != 0 {
+		return 1
+	}
+	return 0
+}
+
+// Bool-returning tests exercise SNEZ/SEQZ value-context Zbs rules.
+func bitBEXTBoolConst(a uint64) bool {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXTI\t[$]10"
+	return a&(1<<10) != 0
+}
+
+func bitBEXTBoolConstZero(a uint64) bool {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXTI\t[$]10"
+	return a&(1<<10) == 0
+}
+
+func bitBEXTBoolVar(a, b uint64) bool {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXT"
+	return a&(1<<(b&63)) != 0
+}
+
+func bitBEXTBoolVarZero(a, b uint64) bool {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXT"
+	return a&(1<<(b&63)) == 0
+}
+
+func bitBEXTBool32Const(a uint32) bool {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXTI\t[$]10"
+	return a&(1<<10) != 0
+}
+
+func bitBEXTBool32Var(a, b uint32) bool {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXT"
+	return a&(1<<(b&31)) != 0
+}
+
 func issue48467(x, y uint64) uint64 {
 	// arm64: -"NEG"
 	d, borrow := bits.Sub64(x, y, 0)

--- a/test/codegen/bits.go
+++ b/test/codegen/bits.go
@@ -569,6 +569,52 @@ func bitBEXTBool32Var(a, b uint32) bool {
 	return a&(1<<(b&31)) != 0
 }
 
+func bitBEXTBool32Var2(a, b uint32) bool {
+	//  riscv64/rva22u64,riscv64/rva23u64:-"BEXT"
+	return a&(1<<b) != 0
+}
+
+func bitBEXTBool32Var4(a, b uint64) bool {
+	//  riscv64/rva22u64,riscv64/rva23u64:-"BEXT"
+	return uint32(a&(1<<(b&63))) != 0
+}
+
+func bitBEXTBool64Var4(x int, y uint) bool {
+	if y < 64 {
+		//  riscv64/rva22u64,riscv64/rva23u64:-"BEXT"
+		return int32(x&(1<<y)) != 0
+	}
+	return false
+}
+
+func bitcheck32FromUint64(x uint64, y uint32) int {
+	//  riscv64/rva22u64,riscv64/rva23u64:"BEXT"
+	if uint32(x)&(1<<(y&31)) != 0 {
+		return 1
+	}
+	return 0
+}
+
+// Unsafe version WITHOUT inner MOVWUreg protection:
+// uint64(x) & (1 << y) where x is uint64 with high bits set.
+// This should use AND + SLL directly (no MOVWUreg), NOT BEXT,
+// because BEXT reads from the original 64-bit x.
+// We expect the compiler to generate AND + SLL (no BEXT).
+func bitcheck64Direct(x uint64, y uint32) int {
+	//  riscv64/rva22u64,riscv64/rva23u64: -"BEXT"
+	if x&(1<<y) != 0 {
+		return 1
+	}
+	return 0
+}
+
+func bitcheck64Direct2(x uint64, y uint32) int {
+	//  riscv64/rva22u64,riscv64/rva23u64: -"BEXT"
+	if int32(x&(1<<y)) != 0 {
+		return 1
+	}
+	return 0
+}
 func issue48467(x, y uint64) uint64 {
 	// arm64: -"NEG"
 	d, borrow := bits.Sub64(x, y, 0)


### PR DESCRIPTION
Fix several errors in the Zbs instruction rules.

Update #73 