### PR TITLE
cmd/compile/internal/ssa: strength reduction for multiply by small constants on riscv64

### DIFF
--- a/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
@@ -931,5 +931,48 @@
 (MOVHload  [off] {sym} (SB) _) && symIsRO(sym) => (MOVDconst [int64(int16(read16(sym, int64(off), config.ctxt.Arch.ByteOrder)))])
 (MOVWload  [off] {sym} (SB) _) && symIsRO(sym) => (MOVDconst [int64(int32(read32(sym, int64(off), config.ctxt.Arch.ByteOrder)))])
 
+// Strength reduction: multiply by small constants (Zba SH*ADD on RVA22+).
+// Generic Mul(64|32) rules handle const-fold, by-0/1/-1, and power-of-two
+// cases; these only cover RISC-V-specific patterns.
+
+(MUL x (MOVDconst [3])) && buildcfg.GORISCV64 >= 22 => (SH1ADD <x.Type> x x)
+(MUL x (MOVDconst [5])) && buildcfg.GORISCV64 >= 22 => (SH2ADD <x.Type> x x)
+(MUL x (MOVDconst [9])) && buildcfg.GORISCV64 >= 22 => (SH3ADD <x.Type> x x)
+(MULW x (MOVDconst [3])) && buildcfg.GORISCV64 >= 22 => (MOVWreg (SH1ADD <x.Type> x x))
+(MULW x (MOVDconst [5])) && buildcfg.GORISCV64 >= 22 => (MOVWreg (SH2ADD <x.Type> x x))
+(MULW x (MOVDconst [9])) && buildcfg.GORISCV64 >= 22 => (MOVWreg (SH3ADD <x.Type> x x))
+
+// Generic patterns: c = (2^n+1) * 2^m where n∈{1,2,3}, m≥1 (covers 6,10,12,18,20,24,...).
+(MUL x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && c%3==0 && isPowerOfTwo(c/3) && c>3 =>
+	(SLLI <x.Type> [int64(log64(c/3))] (SH1ADD <x.Type> x x))
+(MUL x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && c%5==0 && isPowerOfTwo(c/5) && c>5 =>
+	(SLLI <x.Type> [int64(log64(c/5))] (SH2ADD <x.Type> x x))
+(MUL x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && c%9==0 && isPowerOfTwo(c/9) && c>9 =>
+	(SLLI <x.Type> [int64(log64(c/9))] (SH3ADD <x.Type> x x))
+
+// Negative SH*ADD constants for MUL.
+(MUL x (MOVDconst [-3])) && buildcfg.GORISCV64 >= 22 => (NEG (SH1ADD <x.Type> x x))
+(MUL x (MOVDconst [-5])) && buildcfg.GORISCV64 >= 22 => (NEG (SH2ADD <x.Type> x x))
+(MUL x (MOVDconst [-9])) && buildcfg.GORISCV64 >= 22 => (NEG (SH3ADD <x.Type> x x))
+(MUL x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && c%3==0 && isPowerOfTwo((-c)/3) && c < -3 =>
+	(NEG (SLLI <x.Type> [int64(log64((-c)/3))] (SH1ADD <x.Type> x x)))
+(MUL x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && c%5==0 && isPowerOfTwo((-c)/5) && c < -5 =>
+	(NEG (SLLI <x.Type> [int64(log64((-c)/5))] (SH2ADD <x.Type> x x)))
+(MUL x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && c%9==0 && isPowerOfTwo((-c)/9) && c < -9 =>
+	(NEG (SLLI <x.Type> [int64(log64((-c)/9))] (SH3ADD <x.Type> x x)))
+
+// MULW generic SH*ADD+SLLIW patterns (positive).
+(MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)%3==0 && isPowerOfTwo(int32(c)/3) && int32(c)>3 =>
+	(SLLIW <x.Type> [int64(log64(int64(int32(c)/3)))] (SH1ADD <x.Type> x x))
+(MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)%5==0 && isPowerOfTwo(int32(c)/5) && int32(c)>5 =>
+	(SLLIW <x.Type> [int64(log64(int64(int32(c)/5)))] (SH2ADD <x.Type> x x))
+(MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)%9==0 && isPowerOfTwo(int32(c)/9) && int32(c)>9 =>
+	(SLLIW <x.Type> [int64(log64(int64(int32(c)/9)))] (SH3ADD <x.Type> x x))
+
+// Negative SH*ADD constants for MULW.
+(MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)==-3 => (NEGW (SH1ADD <x.Type> x x))
+(MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)==-5 => (NEGW (SH2ADD <x.Type> x x))
+(MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)==-9 => (NEGW (SH3ADD <x.Type> x x))
+
 (PrefetchCache ...)   => (PREFETCH ...)
 (PrefetchCacheStreamed ...) => (PREFETCHNT ...)

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64.go
@@ -590,6 +590,10 @@ func rewriteValueRISCV64(v *Value) bool {
 		return rewriteValueRISCV64_OpRISCV64MOVWstore(v)
 	case OpRISCV64MOVWstorezero:
 		return rewriteValueRISCV64_OpRISCV64MOVWstorezero(v)
+	case OpRISCV64MUL:
+		return rewriteValueRISCV64_OpRISCV64MUL(v)
+	case OpRISCV64MULW:
+		return rewriteValueRISCV64_OpRISCV64MULW(v)
 	case OpRISCV64NEG:
 		return rewriteValueRISCV64_OpRISCV64NEG(v)
 	case OpRISCV64NEGW:
@@ -6473,6 +6477,441 @@ func rewriteValueRISCV64_OpRISCV64MOVWstorezero(v *Value) bool {
 		v.Aux = symToAux(sym)
 		v.AddArg2(base, mem)
 		return true
+	}
+	return false
+}
+func rewriteValueRISCV64_OpRISCV64MUL(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	b := v.Block
+	// match: (MUL x (MOVDconst [3]))
+	// cond: buildcfg.GORISCV64 >= 22
+	// result: (SH1ADD <x.Type> x x)
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1.AuxInt) != 3 || !(buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64SH1ADD)
+			v.Type = x.Type
+			v.AddArg2(x, x)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [5]))
+	// cond: buildcfg.GORISCV64 >= 22
+	// result: (SH2ADD <x.Type> x x)
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1.AuxInt) != 5 || !(buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64SH2ADD)
+			v.Type = x.Type
+			v.AddArg2(x, x)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [9]))
+	// cond: buildcfg.GORISCV64 >= 22
+	// result: (SH3ADD <x.Type> x x)
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1.AuxInt) != 9 || !(buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64SH3ADD)
+			v.Type = x.Type
+			v.AddArg2(x, x)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && c%3==0 && isPowerOfTwo(c/3) && c>3
+	// result: (SLLI <x.Type> [int64(log64(c/3))] (SH1ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && c%3 == 0 && isPowerOfTwo(c/3) && c > 3) {
+				continue
+			}
+			v.reset(OpRISCV64SLLI)
+			v.Type = x.Type
+			v.AuxInt = int64ToAuxInt(int64(log64(c / 3)))
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH1ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && c%5==0 && isPowerOfTwo(c/5) && c>5
+	// result: (SLLI <x.Type> [int64(log64(c/5))] (SH2ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && c%5 == 0 && isPowerOfTwo(c/5) && c > 5) {
+				continue
+			}
+			v.reset(OpRISCV64SLLI)
+			v.Type = x.Type
+			v.AuxInt = int64ToAuxInt(int64(log64(c / 5)))
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH2ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && c%9==0 && isPowerOfTwo(c/9) && c>9
+	// result: (SLLI <x.Type> [int64(log64(c/9))] (SH3ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && c%9 == 0 && isPowerOfTwo(c/9) && c > 9) {
+				continue
+			}
+			v.reset(OpRISCV64SLLI)
+			v.Type = x.Type
+			v.AuxInt = int64ToAuxInt(int64(log64(c / 9)))
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH3ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [-3]))
+	// cond: buildcfg.GORISCV64 >= 22
+	// result: (NEG (SH1ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1.AuxInt) != -3 || !(buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64NEG)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH1ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [-5]))
+	// cond: buildcfg.GORISCV64 >= 22
+	// result: (NEG (SH2ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1.AuxInt) != -5 || !(buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64NEG)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH2ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [-9]))
+	// cond: buildcfg.GORISCV64 >= 22
+	// result: (NEG (SH3ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1.AuxInt) != -9 || !(buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64NEG)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH3ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && c%3==0 && isPowerOfTwo((-c)/3) && c < -3
+	// result: (NEG (SLLI <x.Type> [int64(log64((-c)/3))] (SH1ADD <x.Type> x x)))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && c%3 == 0 && isPowerOfTwo((-c)/3) && c < -3) {
+				continue
+			}
+			v.reset(OpRISCV64NEG)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SLLI, x.Type)
+			v0.AuxInt = int64ToAuxInt(int64(log64((-c) / 3)))
+			v1 := b.NewValue0(v.Pos, OpRISCV64SH1ADD, x.Type)
+			v1.AddArg2(x, x)
+			v0.AddArg(v1)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && c%5==0 && isPowerOfTwo((-c)/5) && c < -5
+	// result: (NEG (SLLI <x.Type> [int64(log64((-c)/5))] (SH2ADD <x.Type> x x)))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && c%5 == 0 && isPowerOfTwo((-c)/5) && c < -5) {
+				continue
+			}
+			v.reset(OpRISCV64NEG)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SLLI, x.Type)
+			v0.AuxInt = int64ToAuxInt(int64(log64((-c) / 5)))
+			v1 := b.NewValue0(v.Pos, OpRISCV64SH2ADD, x.Type)
+			v1.AddArg2(x, x)
+			v0.AddArg(v1)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MUL x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && c%9==0 && isPowerOfTwo((-c)/9) && c < -9
+	// result: (NEG (SLLI <x.Type> [int64(log64((-c)/9))] (SH3ADD <x.Type> x x)))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && c%9 == 0 && isPowerOfTwo((-c)/9) && c < -9) {
+				continue
+			}
+			v.reset(OpRISCV64NEG)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SLLI, x.Type)
+			v0.AuxInt = int64ToAuxInt(int64(log64((-c) / 9)))
+			v1 := b.NewValue0(v.Pos, OpRISCV64SH3ADD, x.Type)
+			v1.AddArg2(x, x)
+			v0.AddArg(v1)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	return false
+}
+func rewriteValueRISCV64_OpRISCV64MULW(v *Value) bool {
+	v_1 := v.Args[1]
+	v_0 := v.Args[0]
+	b := v.Block
+	// match: (MULW x (MOVDconst [3]))
+	// cond: buildcfg.GORISCV64 >= 22
+	// result: (MOVWreg (SH1ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1.AuxInt) != 3 || !(buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64MOVWreg)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH1ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MULW x (MOVDconst [5]))
+	// cond: buildcfg.GORISCV64 >= 22
+	// result: (MOVWreg (SH2ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1.AuxInt) != 5 || !(buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64MOVWreg)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH2ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MULW x (MOVDconst [9]))
+	// cond: buildcfg.GORISCV64 >= 22
+	// result: (MOVWreg (SH3ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst || auxIntToInt64(v_1.AuxInt) != 9 || !(buildcfg.GORISCV64 >= 22) {
+				continue
+			}
+			v.reset(OpRISCV64MOVWreg)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH3ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MULW x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && int32(c)%3==0 && isPowerOfTwo(int32(c)/3) && int32(c)>3
+	// result: (SLLIW <x.Type> [int64(log64(int64(int32(c)/3)))] (SH1ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && int32(c)%3 == 0 && isPowerOfTwo(int32(c)/3) && int32(c) > 3) {
+				continue
+			}
+			v.reset(OpRISCV64SLLIW)
+			v.Type = x.Type
+			v.AuxInt = int64ToAuxInt(int64(log64(int64(int32(c) / 3))))
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH1ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MULW x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && int32(c)%5==0 && isPowerOfTwo(int32(c)/5) && int32(c)>5
+	// result: (SLLIW <x.Type> [int64(log64(int64(int32(c)/5)))] (SH2ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && int32(c)%5 == 0 && isPowerOfTwo(int32(c)/5) && int32(c) > 5) {
+				continue
+			}
+			v.reset(OpRISCV64SLLIW)
+			v.Type = x.Type
+			v.AuxInt = int64ToAuxInt(int64(log64(int64(int32(c) / 5))))
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH2ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MULW x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && int32(c)%9==0 && isPowerOfTwo(int32(c)/9) && int32(c)>9
+	// result: (SLLIW <x.Type> [int64(log64(int64(int32(c)/9)))] (SH3ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && int32(c)%9 == 0 && isPowerOfTwo(int32(c)/9) && int32(c) > 9) {
+				continue
+			}
+			v.reset(OpRISCV64SLLIW)
+			v.Type = x.Type
+			v.AuxInt = int64ToAuxInt(int64(log64(int64(int32(c) / 9))))
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH3ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MULW x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && int32(c)==-3
+	// result: (NEGW (SH1ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && int32(c) == -3) {
+				continue
+			}
+			v.reset(OpRISCV64NEGW)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH1ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MULW x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && int32(c)==-5
+	// result: (NEGW (SH2ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && int32(c) == -5) {
+				continue
+			}
+			v.reset(OpRISCV64NEGW)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH2ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
+	}
+	// match: (MULW x (MOVDconst [c]))
+	// cond: buildcfg.GORISCV64 >= 22 && int32(c)==-9
+	// result: (NEGW (SH3ADD <x.Type> x x))
+	for {
+		for _i0 := 0; _i0 <= 1; _i0, v_0, v_1 = _i0+1, v_1, v_0 {
+			x := v_0
+			if v_1.Op != OpRISCV64MOVDconst {
+				continue
+			}
+			c := auxIntToInt64(v_1.AuxInt)
+			if !(buildcfg.GORISCV64 >= 22 && int32(c) == -9) {
+				continue
+			}
+			v.reset(OpRISCV64NEGW)
+			v0 := b.NewValue0(v.Pos, OpRISCV64SH3ADD, x.Type)
+			v0.AddArg2(x, x)
+			v.AddArg(v0)
+			return true
+		}
+		break
 	}
 	return false
 }

--- a/src/cmd/compile/internal/test/bench_test.go
+++ b/src/cmd/compile/internal/test/bench_test.go
@@ -122,3 +122,325 @@ func BenchmarkBitToggleConst(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkMul64Const3(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 3
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const5(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 5
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const6(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 6
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const8(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 8
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const9(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 9
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const10(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 10
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const12(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 12
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul32Const3(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 3
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32Const6(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 6
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32Const10(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 10
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul64Const18(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 18
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const20(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 20
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const24(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 24
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const36(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 36
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const40(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 40
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64Const72(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 72
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+// 64-bit negative SH*ADD patterns.
+
+func BenchmarkMul64ConstNeg3(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -3
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64ConstNeg5(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -5
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64ConstNeg6(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -6
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64ConstNeg9(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -9
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64ConstNeg10(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -10
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64ConstNeg12(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -12
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul64ConstNeg18(b *testing.B) {
+	var s, x int64
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -18
+		x = (s ^ int64(i)) & 0xfff
+	}
+	globl = s
+}
+
+func BenchmarkMul32Const5(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 5
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32Const9(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 9
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32Const12(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 12
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32Const18(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 18
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32Const20(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 20
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32Const36(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * 36
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32ConstNeg3(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -3
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32ConstNeg5(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -5
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}
+
+func BenchmarkMul32ConstNeg9(b *testing.B) {
+	var s, x int32
+	x = 7
+	for i := 0; i < b.N; i++ {
+		s += x * -9
+		x = int32((int64(s) ^ int64(i)) & 0xfff)
+	}
+	globl32 = s
+}

--- a/test/codegen/multiply.go
+++ b/test/codegen/multiply.go
@@ -17,26 +17,34 @@ func m0(x int64) int64 {
 func m2(x int64) int64 {
 	// amd64: "ADDQ"
 	// arm64: "ADD"
+	// riscv64:"SLLI\t[$]1"
 	return x * 2
 }
 func m3(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]2"
 	// arm64: "ADD\tR[0-9]+<<1,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH1ADD\t",-"MUL\t"
 	return x * 3
 }
 func m4(x int64) int64 {
 	// amd64: "SHLQ\t[$]2,"
 	// arm64: "LSL\t[$]2,"
+	// riscv64:"SLLI\t[$]2"
 	return x * 4
 }
 func m5(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]4"
 	// arm64: "ADD\tR[0-9]+<<2,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH2ADD\t",-"MUL\t"
 	return x * 5
 }
 func m6(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]1", "LEAQ\t.*[*]2"
 	// arm64: "ADD\tR[0-9]+,", "ADD\tR[0-9]+<<1,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH1ADD\t", "SLLI\t[$]1",-"MUL\t"
 	return x * 6
 }
 func m7(x int64) int64 {
@@ -47,16 +55,21 @@ func m7(x int64) int64 {
 func m8(x int64) int64 {
 	// amd64: "SHLQ\t[$]3,"
 	// arm64: "LSL\t[$]3,"
+	// riscv64:"SLLI\t[$]3"
 	return x * 8
 }
 func m9(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]8"
 	// arm64: "ADD\tR[0-9]+<<3,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH3ADD\t",-"MUL\t"
 	return x * 9
 }
 func m10(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]1", "LEAQ\t.*[*]4"
 	// arm64: "ADD\tR[0-9]+,", "ADD\tR[0-9]+<<2,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH2ADD\t", "SLLI\t[$]1",-"MUL\t"
 	return x * 10
 }
 func m11(x int64) int64 {
@@ -67,6 +80,8 @@ func m11(x int64) int64 {
 func m12(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]2", "SHLQ\t[$]2,"
 	// arm64: "LSL\t[$]2,", "ADD\tR[0-9]+<<1,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH1ADD\t", "SLLI\t[$]2",-"MUL\t"
 	return x * 12
 }
 func m13(x int64) int64 {
@@ -97,6 +112,8 @@ func m17(x int64) int64 {
 func m18(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]1", "LEAQ\t.*[*]8"
 	// arm64: "ADD\tR[0-9]+,", "ADD\tR[0-9]+<<3,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH3ADD\t", "SLLI\t[$]1",-"MUL\t"
 	return x * 18
 }
 func m19(x int64) int64 {
@@ -107,6 +124,8 @@ func m19(x int64) int64 {
 func m20(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]4", "SHLQ\t[$]2,"
 	// arm64: "LSL\t[$]2,", "ADD\tR[0-9]+<<2,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH2ADD\t", "SLLI\t[$]2",-"MUL\t"
 	return x * 20
 }
 func m21(x int64) int64 {
@@ -127,6 +146,8 @@ func m23(x int64) int64 {
 func m24(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]2", "SHLQ\t[$]3,"
 	// arm64: "LSL\t[$]3,", "ADD\tR[0-9]+<<1,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH1ADD\t", "SLLI\t[$]3",-"MUL\t"
 	return x * 24
 }
 func m25(x int64) int64 {
@@ -146,7 +167,7 @@ func m27(x int64) int64 {
 }
 func m28(x int64) int64 {
 	// amd64: "IMUL3Q\t[$]28,"
-	// arm64: "LSL\t[$]5, "SUB\tR[0-9]+<<2,"
+	// arm64: "LSL\t[$]5,", "SUB\tR[0-9]+<<2,"
 	return x * 28
 }
 func m29(x int64) int64 {
@@ -187,6 +208,8 @@ func m35(x int64) int64 {
 func m36(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]8", "SHLQ\t[$]2,"
 	// arm64: "LSL\t[$]2,", "ADD\tR[0-9]+<<3,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH3ADD\t", "SLLI\t[$]2",-"MUL\t"
 	return x * 36
 }
 func m37(x int64) int64 {
@@ -207,7 +230,14 @@ func m39(x int64) int64 {
 func m40(x int64) int64 {
 	// amd64: "LEAQ\t.*[*]4", "SHLQ\t[$]3,"
 	// arm64: "LSL\t[$]3,", "ADD\tR[0-9]+<<2,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH2ADD\t", "SLLI\t[$]3",-"MUL\t"
 	return x * 40
+}
+func m72(x int64) int64 {
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH3ADD\t", "SLLI\t[$]3",-"MUL\t"
+	return x * 72
 }
 
 func mn1(x int64) int64 {
@@ -223,6 +253,8 @@ func mn2(x int64) int64 {
 func mn3(x int64) int64 {
 	// amd64: "NEGQ", "LEAQ\t.*[*]2"
 	// arm64: "SUB\tR[0-9]+<<2,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH1ADD\t", "NEG\t",-"MUL\t"
 	return x * -3
 }
 func mn4(x int64) int64 {
@@ -233,11 +265,15 @@ func mn4(x int64) int64 {
 func mn5(x int64) int64 {
 	// amd64: "NEGQ", "LEAQ\t.*[*]4"
 	// arm64: "NEG\tR[0-9]+,", "ADD\tR[0-9]+<<2,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH2ADD\t", "NEG\t",-"MUL\t"
 	return x * -5
 }
 func mn6(x int64) int64 {
 	// amd64: "IMUL3Q\t[$]-6,"
 	// arm64: "ADD\tR[0-9]+,", "SUB\tR[0-9]+<<2,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH1ADD\t", "SLLI\t[$]1", "NEG\t"
 	return x * -6
 }
 func mn7(x int64) int64 {
@@ -253,11 +289,15 @@ func mn8(x int64) int64 {
 func mn9(x int64) int64 {
 	// amd64: "NEGQ", "LEAQ\t.*[*]8"
 	// arm64: "NEG\tR[0-9]+,", "ADD\tR[0-9]+<<3,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH3ADD\t", "NEG\t",-"MUL\t"
 	return x * -9
 }
 func mn10(x int64) int64 {
 	// amd64: "IMUL3Q\t[$]-10,"
 	// arm64: "MOVD\t[$]-10,", "MUL"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH2ADD\t", "SLLI\t[$]1", "NEG\t"
 	return x * -10
 }
 func mn11(x int64) int64 {
@@ -268,6 +308,8 @@ func mn11(x int64) int64 {
 func mn12(x int64) int64 {
 	// amd64: "IMUL3Q\t[$]-12,"
 	// arm64: "LSL\t[$]2,", "SUB\tR[0-9]+<<2,"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH1ADD\t", "SLLI\t[$]2", "NEG\t"
 	return x * -12
 }
 func mn13(x int64) int64 {
@@ -298,6 +340,8 @@ func mn17(x int64) int64 {
 func mn18(x int64) int64 {
 	// amd64: "IMUL3Q\t[$]-18,"
 	// arm64: "MOVD\t[$]-18,", "MUL"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH3ADD\t", "SLLI\t[$]1", "NEG\t"
 	return x * -18
 }
 func mn19(x int64) int64 {
@@ -308,5 +352,90 @@ func mn19(x int64) int64 {
 func mn20(x int64) int64 {
 	// amd64: "IMUL3Q\t[$]-20,"
 	// arm64: "MOVD\t[$]-20,", "MUL"
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH2ADD\t", "SLLI\t[$]2", "NEG\t"
 	return x * -20
+}
+func mn24(x int64) int64 {
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH1ADD\t", "SLLI\t[$]3", "NEG\t"
+	return x * -24
+}
+func mn36(x int64) int64 {
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH3ADD\t", "SLLI\t[$]2", "NEG\t"
+	return x * -36
+}
+func mn40(x int64) int64 {
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH2ADD\t", "SLLI\t[$]3", "NEG\t"
+	return x * -40
+}
+func mn72(x int64) int64 {
+	// riscv64/rva20u64:"MUL\t"
+	// riscv64/rva22u64:"SH3ADD\t", "SLLI\t[$]3", "NEG\t"
+	return x * -72
+}
+
+// 32-bit multiply strength reduction tests.
+
+func mul32By3(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH1ADD\t", "MOVW\t", -"MULW\t"
+	return x * 3
+}
+func mul32By5(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH2ADD\t", "MOVW\t", -"MULW\t"
+	return x * 5
+}
+func mul32By9(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH3ADD\t", "MOVW\t", -"MULW\t"
+	return x * 9
+}
+func mul32By6(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH1ADD\t", "SLLIW\t[$]1", -"MULW\t"
+	return x * 6
+}
+func mul32By12(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH1ADD\t", "SLLIW\t[$]2", -"MULW\t"
+	return x * 12
+}
+func mul32By10(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH2ADD\t", "SLLIW\t[$]1", -"MULW\t"
+	return x * 10
+}
+func mul32By20(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH2ADD\t", "SLLIW\t[$]2", -"MULW\t"
+	return x * 20
+}
+func mul32By18(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH3ADD\t", "SLLIW\t[$]1", -"MULW\t"
+	return x * 18
+}
+func mul32By36(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH3ADD\t", "SLLIW\t[$]2", -"MULW\t"
+	return x * 36
+}
+func mul32ByNeg3(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH1ADD\t", "NEGW\t", -"MULW\t"
+	return x * (-3)
+}
+func mul32ByNeg5(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH2ADD\t", "NEGW\t", -"MULW\t"
+	return x * (-5)
+}
+func mul32ByNeg9(x int32) int32 {
+	// riscv64/rva20u64:"MULW\t"
+	// riscv64/rva22u64:"SH3ADD\t", "NEGW\t", -"MULW\t"
+	return x * (-9)
 }


### PR DESCRIPTION
Leverage RISC-V Zba extension SH*ADD instructions to replace MUL by small
constants (3, 5, 9) with SH1ADD/SH2ADD/SH3ADD, and generalize to composite
constants of the form c = (2^n+1) * 2^m as well as their negative counterparts.

goos: linux
goarch: riscv64
cpu: Spacemit(R) X60
                │ mul_reduction_before.txt │      mul_reduction_after.txt      │
                │          sec/op           │   sec/op     vs base               │
MullImm                         6.447µ ± 0%   6.446µ ± 0%        ~ (p=0.284 n=6)
Mul64Const3                     6.282n ± 0%   3.455n ± 0%  -45.01% (p=0.002 n=6)
Mul64Const5                     6.282n ± 0%   3.455n ± 0%  -45.00% (p=0.002 n=6)
Mul64Const6                     6.282n ± 0%   3.769n ± 0%  -40.00% (p=0.002 n=6)
Mul64Const8                     3.140n ± 0%   3.140n ± 0%        ~ (p=0.870 n=6)
Mul64Const9                     6.283n ± 0%   3.455n ± 0%  -45.01% (p=0.002 n=6)
Mul64Const10                    6.283n ± 0%   3.768n ± 0%  -40.02% (p=0.002 n=6)
Mul64Const12                    6.282n ± 0%   3.769n ± 0%  -40.00% (p=0.002 n=6)
Mul32Const3                     5.653n ± 0%   5.026n ± 0%  -11.10% (p=0.002 n=6)
Mul32Const6                     5.653n ± 0%   5.027n ± 0%  -11.09% (p=0.002 n=6)
Mul32Const10                    5.655n ± 0%   5.027n ± 0%  -11.10% (p=0.002 n=6)
Mul64Const18                    6.285n ± 0%   3.769n ± 0%  -40.02% (p=0.002 n=6)
Mul64Const20                    6.282n ± 0%   3.768n ± 0%  -40.02% (p=0.002 n=6)
Mul64Const24                    6.283n ± 0%   3.769n ± 0%  -40.01% (p=0.002 n=6)
Mul64Const36                    6.282n ± 0%   3.769n ± 0%  -40.00% (p=0.002 n=6)
Mul64Const40                    6.282n ± 0%   3.769n ± 0%  -40.00% (p=0.002 n=6)
Mul64Const72                    6.283n ± 0%   3.770n ± 0%  -40.00% (p=0.002 n=6)
Mul64ConstNeg3                  6.282n ± 0%   3.454n ± 0%  -45.02% (p=0.002 n=6)
Mul64ConstNeg5                  6.282n ± 0%   3.455n ± 0%  -45.01% (p=0.002 n=6)
Mul64ConstNeg6                  6.282n ± 0%   4.083n ± 0%  -35.00% (p=0.002 n=6)
Mul64ConstNeg9                  6.282n ± 0%   3.455n ± 0%  -45.01% (p=0.002 n=6)
Mul64ConstNeg10                 6.285n ± 0%   4.083n ± 0%  -35.02% (p=0.002 n=6)
Mul64ConstNeg12                 6.283n ± 0%   4.082n ± 0%  -35.03% (p=0.002 n=6)
Mul64ConstNeg18                 6.282n ± 0%   4.083n ± 0%  -35.01% (p=0.002 n=6)
Mul32Const5                     5.653n ± 0%   5.026n ± 0%  -11.09% (p=0.002 n=6)
Mul32Const9                     5.653n ± 0%   5.026n ± 0%  -11.10% (p=0.002 n=6)
Mul32Const12                    5.655n ± 0%   5.026n ± 0%  -11.13% (p=0.002 n=6)
Mul32Const18                    5.653n ± 0%   5.026n ± 0%  -11.10% (p=0.002 n=6)
Mul32Const20                    5.653n ± 0%   5.026n ± 0%  -11.11% (p=0.002 n=6)
Mul32Const36                    5.654n ± 0%   5.027n ± 0%  -11.10% (p=0.002 n=6)
Mul32ConstNeg3                  5.653n ± 0%   5.026n ± 0%  -11.09% (p=0.002 n=6)
Mul32ConstNeg5                  5.654n ± 0%   5.026n ± 0%  -11.11% (p=0.002 n=6)
Mul32ConstNeg9                  5.653n ± 0%   5.026n ± 0%  -11.10% (p=0.002 n=6)
geomean                         7.305n        5.183n       -29.04%