### PR TITLE
cmd/compile/internal/ssa: optimize float zero stores to use integer storezero ops on riscv64

### DIFF
--- a/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
@@ -1030,3 +1030,8 @@
 (MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)==-3 => (NEGW (SH1ADD <x.Type> x x))
 (MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)==-5 => (NEGW (SH2ADD <x.Type> x x))
 (MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)==-9 => (NEGW (SH3ADD <x.Type> x x))
+
+// Note: using val.AuxInt raw bit check instead of [0] float comparison because
+// IEEE 754 -0.0 == 0.0 would incorrectly match negative zero.
+(FMOVWstore [off] {sym} ptr val:(FMOVFconst) mem) && int32(val.AuxInt) == 0 => (MOVWstorezero [off] {sym} ptr mem)
+(FMOVDstore [off] {sym} ptr val:(FMOVDconst) mem) && val.AuxInt == 0 => (MOVDstorezero [off] {sym} ptr mem)

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64.go
@@ -4192,6 +4192,27 @@ func rewriteValueRISCV64_OpRISCV64FMOVDstore(v *Value) bool {
 		v.AddArg3(base, val, mem)
 		return true
 	}
+	// match: (FMOVDstore [off] {sym} ptr val:(FMOVDconst) mem)
+	// cond: val.AuxInt == 0
+	// result: (MOVDstorezero [off] {sym} ptr mem)
+	for {
+		off := auxIntToInt32(v.AuxInt)
+		sym := auxToSym(v.Aux)
+		ptr := v_0
+		val := v_1
+		if val.Op != OpRISCV64FMOVDconst {
+			break
+		}
+		mem := v_2
+		if !(val.AuxInt == 0) {
+			break
+		}
+		v.reset(OpRISCV64MOVDstorezero)
+		v.AuxInt = int32ToAuxInt(off)
+		v.Aux = symToAux(sym)
+		v.AddArg2(ptr, mem)
+		return true
+	}
 	return false
 }
 func rewriteValueRISCV64_OpRISCV64FMOVWload(v *Value) bool {
@@ -4312,6 +4333,27 @@ func rewriteValueRISCV64_OpRISCV64FMOVWstore(v *Value) bool {
 		v.AuxInt = int32ToAuxInt(off1 + int32(off2))
 		v.Aux = symToAux(sym)
 		v.AddArg3(base, val, mem)
+		return true
+	}
+	// match: (FMOVWstore [off] {sym} ptr val:(FMOVFconst) mem)
+	// cond: int32(val.AuxInt) == 0
+	// result: (MOVWstorezero [off] {sym} ptr mem)
+	for {
+		off := auxIntToInt32(v.AuxInt)
+		sym := auxToSym(v.Aux)
+		ptr := v_0
+		val := v_1
+		if val.Op != OpRISCV64FMOVFconst {
+			break
+		}
+		mem := v_2
+		if !(int32(val.AuxInt) == 0) {
+			break
+		}
+		v.reset(OpRISCV64MOVWstorezero)
+		v.AuxInt = int32ToAuxInt(off)
+		v.Aux = symToAux(sym)
+		v.AddArg2(ptr, mem)
 		return true
 	}
 	return false

--- a/test/codegen/floats.go
+++ b/test/codegen/floats.go
@@ -313,3 +313,18 @@ func isNegNormal(x float64) bool {
 	// riscv64:"FCLASSD"
 	return x <= -2.2250738585072014e-308
 }
+
+// Storing zero to *float32 / *float64 on riscv64 should use integer store-from-zero
+// (MOVW/MOV with X0) instead of moving zero through an FP register (FMVWX/FMVDX + MOVF/MOVD).
+// SSA names the op FMVSX, but cmd/internal/obj/riscv prints it as FMVWX ("FMVSX is the old name for FMVWX").
+// The assembler lists the zero register as X0, not $0.
+
+func StoreFloat32Zero(p *float32) {
+	// riscv64:"MOVW\\s+X0,",-"FMVWX",-"MOVF"
+	*p = 0
+}
+
+func StoreFloat64Zero(p *float64) {
+	// riscv64:"MOV\\s+X0,",-"FMVDX",-"MOVD"
+	*p = 0
+}


### PR DESCRIPTION
## Related Issue(s) & Descriptions

optimize float zero stores to use integer storezero ops on riscv64

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required