### PR TITLE
cmd/compile/internal/ssa: optimize float zero stores to use integer s…

### DIFF
--- a/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
+++ b/src/cmd/compile/internal/ssa/_gen/RISCV64.rules
@@ -1030,3 +1030,6 @@
 (MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)==-3 => (NEGW (SH1ADD <x.Type> x x))
 (MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)==-5 => (NEGW (SH2ADD <x.Type> x x))
 (MULW x (MOVDconst [c])) && buildcfg.GORISCV64 >= 22 && int32(c)==-9 => (NEGW (SH3ADD <x.Type> x x))
+
+(FMOVWstore [off] {sym} ptr (FMOVFconst [0]) mem) => (MOVWstorezero [off] {sym} ptr mem)
+(FMOVDstore [off] {sym} ptr (FMOVDconst [0]) mem) => (MOVDstorezero [off] {sym} ptr mem)

--- a/src/cmd/compile/internal/ssa/rewriteRISCV64.go
+++ b/src/cmd/compile/internal/ssa/rewriteRISCV64.go
@@ -4192,6 +4192,22 @@ func rewriteValueRISCV64_OpRISCV64FMOVDstore(v *Value) bool {
 		v.AddArg3(base, val, mem)
 		return true
 	}
+	// match: (FMOVDstore [off] {sym} ptr (FMOVDconst [0]) mem)
+	// result: (MOVDstorezero [off] {sym} ptr mem)
+	for {
+		off := auxIntToInt32(v.AuxInt)
+		sym := auxToSym(v.Aux)
+		ptr := v_0
+		if v_1.Op != OpRISCV64FMOVDconst || auxIntToFloat64(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpRISCV64MOVDstorezero)
+		v.AuxInt = int32ToAuxInt(off)
+		v.Aux = symToAux(sym)
+		v.AddArg2(ptr, mem)
+		return true
+	}
 	return false
 }
 func rewriteValueRISCV64_OpRISCV64FMOVWload(v *Value) bool {
@@ -4312,6 +4328,22 @@ func rewriteValueRISCV64_OpRISCV64FMOVWstore(v *Value) bool {
 		v.AuxInt = int32ToAuxInt(off1 + int32(off2))
 		v.Aux = symToAux(sym)
 		v.AddArg3(base, val, mem)
+		return true
+	}
+	// match: (FMOVWstore [off] {sym} ptr (FMOVFconst [0]) mem)
+	// result: (MOVWstorezero [off] {sym} ptr mem)
+	for {
+		off := auxIntToInt32(v.AuxInt)
+		sym := auxToSym(v.Aux)
+		ptr := v_0
+		if v_1.Op != OpRISCV64FMOVFconst || auxIntToFloat32(v_1.AuxInt) != 0 {
+			break
+		}
+		mem := v_2
+		v.reset(OpRISCV64MOVWstorezero)
+		v.AuxInt = int32ToAuxInt(off)
+		v.Aux = symToAux(sym)
+		v.AddArg2(ptr, mem)
 		return true
 	}
 	return false

--- a/test/codegen/floats.go
+++ b/test/codegen/floats.go
@@ -313,3 +313,18 @@ func isNegNormal(x float64) bool {
 	// riscv64:"FCLASSD"
 	return x <= -2.2250738585072014e-308
 }
+
+// Storing zero to *float32 / *float64 on riscv64 should use integer store-from-zero
+// (MOVW/MOV with X0) instead of moving zero through an FP register (FMVWX/FMVDX + MOVF/MOVD).
+// SSA names the op FMVSX, but cmd/internal/obj/riscv prints it as FMVWX ("FMVSX is the old name for FMVWX").
+// The assembler lists the zero register as X0, not $0.
+
+func StoreFloat32Zero(p *float32) {
+	// riscv64:"MOVW\\s+X0,",-"FMVWX",-"MOVF"
+	*p = 0
+}
+
+func StoreFloat64Zero(p *float64) {
+	// riscv64:"MOV\\s+X0,",-"FMVDX",-"MOVD"
+	*p = 0
+}


### PR DESCRIPTION
…torezero ops on riscv64

<!-- 
+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter 
-->

## Related Issue(s) & Descriptions

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required